### PR TITLE
README.md: Fix typo in environment variable used by OpenSSL to find e…

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ Instructions to build and install tpm2-tss are available in the
 In order to use this engine without `make install` for testing call:
 ```
 export LD_LIBRAY_PATH=${TPM2TSS}/src/tss2-{tcti,mu,sys,esys}/.libs
-export OPENSSL_ENGINE=${PWD}/.libs
+export OPENSSL_ENGINES=${PWD}/.libs
 export PATH=${PWD}:${PATH}
 export PKG_CONFIG_PATH=$PWD/../tpm2-tss/lib
 ./bootstrap


### PR DESCRIPTION
…ngines.

The README.md lists this variable as 'OPENSSL_ENGINE' where it should be
'OPENSSL_ENGINES'. The test scripts get this right.

Signed-off-by: Philip Tricca <philip.b.tricca@intel.com>