### PR TITLE
configure.ac: Makefile.am: allow build without pandoc

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -115,6 +115,7 @@ AUTHORS:
 EXTRA_DIST += AUTHORS
 CLEANFILES += AUTHORS
 
+if HAVE_PANDOC
 ### Man Pages
 man1_MANS = \
     man/tpm2tss-genkey.1
@@ -127,6 +128,19 @@ man3_MANS = \
     man/tpm2tss_ecc_getappdata.3 \
     man/tpm2tss_tpm2data_read.3 \
     man/tpm2tss_ecc_setappdata.3
+
+# If pandoc is enabled, we want to generate the manpages for the dist tarball
+EXTRA_DIST += \
+    $(man1_MANS) \
+    $(man3_MANS)
+
+else
+# If pandoc is not enabled, we want to complain that you need pandoc for make dist,
+# so hook the target and complain.
+dist-hook:
+	@(>&2 echo "You do not have pandoc, a requirement for the distribution of manpages")
+	@exit 1
+endif
 
 define man_dir
     mkdir man 2>/dev/null || test -d man

--- a/configure.ac
+++ b/configure.ac
@@ -101,7 +101,9 @@ PKG_CHECK_MODULES([CRYPTO], [libcrypto >= 1.0.2g])
 PKG_CHECK_MODULES([TSS2_ESYS],[tss2-esys])
 
 AC_PATH_PROG([PANDOC], [pandoc])
-AS_IF([test -z "$PANDOC"], AC_MSG_ERROR([Program pandoc not found.]))
+AS_IF([test -z "$PANDOC"],
+    [AC_MSG_WARN([Required executable pandoc not found, man pages will not be built])])
+AM_CONDITIONAL([HAVE_PANDOC],[test -n "$PANDOC"])
 
 AC_OUTPUT
 


### PR DESCRIPTION
Allow the engine to be built even if pandoc is missing. Only create
man pages if pandoc is available. This roughly follows the same
pattern as tpm2-tools.

Address the following issue:
https://github.com/tpm2-software/tpm2-tss-engine/issues/18

Allows the engine to be built in an Alpine Linux environment
