### PR TITLE
doc: Add missing build steps for tpm2-tss

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -25,6 +25,8 @@ sudo apt -y install \
   ruby-ronn
 git clone --depth=1 http://www.github.com/tpm2-software/tpm2-tss
 cd tpm2-tss
+./bootstrap
+./configure
 make -j$(nproc)
 sudo make install
 ```


### PR DESCRIPTION
The build steps for the tpm2-tss dependency are incomplete (they miss
the two calls: ./bootstrap and ./configure, see [1])

[1] https://github.com/tpm2-software/tpm2-tss/blob/master/INSTALL.md

Signed-off-by: Julien Hachenberger <julien.hachenberger@sit.fraunhofer.de>