### PR TITLE
Fix uninitialized variable dereferencing

### DIFF
--- a/src/tpm2-tss-engine-ecc.c
+++ b/src/tpm2-tss-engine-ecc.c
@@ -130,7 +130,7 @@ ecdsa_sign(const unsigned char *dgst, int dgst_len, const BIGNUM *inv,
     DBGBUF(dgst, dgst_len);
 
 	TSS2_RC r;
-    ESYS_CONTEXT *ectx;
+    ESYS_CONTEXT *ectx = NULL;
     ESYS_TR keyHandle = ESYS_TR_NONE;
     TPMT_SIGNATURE *sig = NULL;
 

--- a/src/tpm2-tss-engine-rand.c
+++ b/src/tpm2-tss-engine-rand.c
@@ -50,7 +50,7 @@
 static int
 rand_bytes(unsigned char *buf, int num)
 {
-    ESYS_CONTEXT *ectx;
+    ESYS_CONTEXT *ectx = NULL;
     TSS2_RC r;
 
     r = Esys_Initialize(&ectx, NULL, NULL);


### PR DESCRIPTION
The Esys_Finalize() calls in some of the error handling sections
did contain uninitialized variables for the context.
Fixing this by initializing variables.

Fixes: #48 

@jhachenbergerSIT Would you be so kind and review / test this ?