### PR TITLE
Fix double EC_KEY_free

### DIFF
--- a/src/tpm2-tss-engine-ecc.c
+++ b/src/tpm2-tss-engine-ecc.c
@@ -321,11 +321,13 @@ tpm2tss_ecc_makekey(TPM2_DATA *tpm2Data)
     if (!EC_KEY_set_method(eckey, ecc_methods)) {
 #endif /* OPENSSL_VERSION_NUMBER < 0x10100000 */
         ERR(tpm2tss_ecc_makekey, TPM2TSS_R_GENERAL_FAILURE);
+        EC_KEY_free(eckey);
         goto error;
     }
 
     if (!EVP_PKEY_assign_EC_KEY(pkey, eckey)) {
         ERR(tpm2tss_ecc_makekey, TPM2TSS_R_GENERAL_FAILURE);
+        EC_KEY_free(eckey);
         goto error;
     }
 
@@ -342,7 +344,6 @@ tpm2tss_ecc_makekey(TPM2_DATA *tpm2Data)
     return pkey;
 error:
     EVP_PKEY_free(pkey);
-    EC_KEY_free(eckey);
     return NULL;
 }
 

--- a/src/tpm2-tss-engine-rsa.c
+++ b/src/tpm2-tss-engine-rsa.c
@@ -435,6 +435,7 @@ tpm2tss_rsa_makekey(TPM2_DATA *tpm2Data)
 
     if (!EVP_PKEY_assign_RSA(pkey, rsa)) {
         ERR(populate_rsa, TPM2TSS_R_GENERAL_FAILURE);
+        RSA_free(rsa);
         goto error;
     }
 
@@ -450,8 +451,7 @@ tpm2tss_rsa_makekey(TPM2_DATA *tpm2Data)
 
     return pkey;
 error:
-    if (pkey) EVP_PKEY_free(pkey);
-    if (rsa) RSA_free(rsa);
+    EVP_PKEY_free(pkey);
     return NULL;
 }
 


### PR DESCRIPTION
Apparently, the EVP_KEY_free() also frees an assigned EC_KEY.
Thus the free'ing of the EC_KEY in the error section became a
double-free.
Same applies to RSA_KEY.

Fixes: #29 