### PR TITLE
Enable emptyAuth detection for noda persistent keys

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,6 +28,7 @@ addons:
     - libssl-dev
     - uthash-dev
     - pandoc
+    - expect
 
 install:
   - git clean -xdf

--- a/Makefile.am
+++ b/Makefile.am
@@ -103,7 +103,8 @@ TESTS = test/ecdsa.sh \
         test/rsasign.sh \
         test/failload.sh \
         test/failwrite.sh \
-        test/rsasign_persistent.sh
+        test/rsasign_persistent.sh \
+        test/rsasign_persistent_emptyauth.sh
 EXTRA_DIST += $(TESTS)
 
 # Adding user and developer information

--- a/configure.ac
+++ b/configure.ac
@@ -107,6 +107,10 @@ AS_IF([test -z "$PANDOC"],
     [AC_MSG_WARN([Required executable pandoc not found, man pages will not be built])])
 AM_CONDITIONAL([HAVE_PANDOC],[test -n "$PANDOC"])
 
+AC_PATH_PROG([EXPECT], [expect])
+AS_IF([test -z "$PANDOC"],
+    [AC_MSG_WARN([Required executable expect not found, some tests might fail])])
+
 AC_ARG_WITH([enginesdir], 
             [AS_HELP_STRING([--with-enginesdir],
                             [Set the OpenSSL engine directory (default: use pkg-config)])],

--- a/test/rsasign_persistent_emptyauth.sh
+++ b/test/rsasign_persistent_emptyauth.sh
@@ -1,0 +1,60 @@
+#!/bin/bash
+
+set -eufx
+
+export OPENSSL_ENGINES=${PWD}/.libs
+export LD_LIBRARY_PATH=$OPENSSL_ENGINES:${LD_LIBRARY_PATH-}
+export PATH=${PWD}:${PATH}
+
+DIR=$(mktemp -d)
+echo -n "abcde12345abcde12345">${DIR}/mydata.txt
+
+# Create an Primary key pair
+echo "Generating primary key"
+PARENT_CTX=${DIR}/primary_owner_key.ctx
+
+tpm2_startup -T mssim -c || true
+
+tpm2_createprimary -T mssim -a o -g sha256 -G rsa -o ${PARENT_CTX}
+tpm2_flushcontext -T mssim -t
+
+# Create an RSA key pair
+echo "Generating RSA key pair"
+TPM_RSA_PUBKEY=${DIR}/rsakey.pub
+TPM_RSA_KEY=${DIR}/rsakey
+tpm2_create -T mssim -C ${PARENT_CTX} -g sha256 -G rsa -u ${TPM_RSA_PUBKEY} -r ${TPM_RSA_KEY} -A sign\|decrypt\|fixedtpm\|fixedparent\|sensitivedataorigin\|userwithauth\|noda
+tpm2_flushcontext -T mssim -t
+
+# Load Key to persistent handle
+RSA_CTX=${DIR}/rsakey.ctx
+tpm2_load -T mssim -C ${PARENT_CTX} -u ${TPM_RSA_PUBKEY} -r ${TPM_RSA_KEY} -o ${RSA_CTX}
+tpm2_flushcontext -T mssim -t
+
+HANDLE=$(tpm2_evictcontrol -T mssim -a o -c ${RSA_CTX} | cut -d ' ' -f 2)
+tpm2_flushcontext -T mssim -t
+
+# Signing Data
+#Actually signing should not require an auth value
+if ! openssl pkeyutl -engine tpm2tss -keyform engine -inkey ${HANDLE} -sign -in ${DIR}/mydata.txt -out ${DIR}/mysig -passin file:notexists; then
+#The expect script is only here, because tpm2-tss <2.2 had some bug, and thus us asking for passwords when none were required.
+expect <<EOF
+spawn openssl pkeyutl -engine tpm2tss -keyform engine -inkey ${HANDLE} -sign -in ${DIR}/mydata.txt -out ${DIR}/mysig -passin stdin
+expect "Enter password for user key:"
+send "\r\n"
+expect eof
+EOF
+fi
+
+# Get public key of handle
+tpm2_readpublic -T mssim -c ${HANDLE} -o ${DIR}/mykey.pem -f pem
+
+# Release persistent HANDLE
+tpm2_evictcontrol -T mssim -a o -c ${HANDLE}
+
+tpm2_flushcontext -T mssim -t -l
+
+R="$(openssl pkeyutl -pubin -inkey ${DIR}/mykey.pem -verify -in ${DIR}/mydata.txt -sigfile ${DIR}/mysig || true)"
+if ! echo $R | grep "Signature Verified Successfully" >/dev/null; then
+    echo $R
+    exit 1
+fi


### PR DESCRIPTION
If a persistent key is requested and this key has the noda flag set, we will attempt to authenticate with an
empty auth. This helps to save the user a password prompt.

Fixes: #13 