### PR TITLE
Add support for persistent parents

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -103,6 +103,7 @@ TESTS = test/ecdsa.sh \
         test/rsasign.sh \
         test/failload.sh \
         test/failwrite.sh \
+        test/rsasign_parent.sh \
         test/rsasign_persistent.sh \
         test/rsasign_persistent_emptyauth.sh
 EXTRA_DIST += $(TESTS)

--- a/include/tpm2-tss-engine.h
+++ b/include/tpm2-tss-engine.h
@@ -43,11 +43,12 @@ typedef struct {
     int emptyAuth;
     TPM2B_DIGEST userauth;
     TPM2B_PUBLIC pub;
+    TPM2_HANDLE parent;
+    KEY_TYPE privatetype;
     union {
       TPM2B_PRIVATE priv;
       TPM2_HANDLE handle;
     };
-    KEY_TYPE privatetype;
 } TPM2_DATA;
 
 #define TPM2TSS_SET_OWNERAUTH ENGINE_CMD_BASE
@@ -65,13 +66,15 @@ EVP_PKEY *
 tpm2tss_rsa_makekey(TPM2_DATA *tpm2Data);
 
 int
-tpm2tss_rsa_genkey(RSA *rsa, int bits, BIGNUM *e, char *password);
+tpm2tss_rsa_genkey(RSA *rsa, int bits, BIGNUM *e, char *password,
+                   TPM2_HANDLE parentHandle);
 
 EVP_PKEY *
 tpm2tss_ecc_makekey(TPM2_DATA *tpm2Data);
 
 int
-tpm2tss_ecc_genkey(EC_KEY *key, TPMI_ECC_CURVE curve, const char *password);
+tpm2tss_ecc_genkey(EC_KEY *key, TPMI_ECC_CURVE curve, const char *password,
+                   TPM2_HANDLE parentHandle);
 
 TPM2_DATA *
 tpm2tss_ecc_getappdata(EC_KEY *key);

--- a/src/tpm2-tss-engine-common.h
+++ b/src/tpm2-tss-engine-common.h
@@ -47,7 +47,8 @@ int init_ecc(ENGINE *e);
 int init_rand(ENGINE *e);
 int init_rsa(ENGINE *e);
 
-TSS2_RC init_tpm_primary(ESYS_CONTEXT **ctx, ESYS_TR *primaryHandle);
+TSS2_RC init_tpm_parent(ESYS_CONTEXT **ctx, uint32_t parentHandle,
+                        ESYS_TR *parent);
 TSS2_RC init_tpm_key(ESYS_CONTEXT **ctx, ESYS_TR *keyHandle,
                      TPM2_DATA *tpm2Data);
 

--- a/src/tpm2-tss-engine-err.c
+++ b/src/tpm2-tss-engine-err.c
@@ -52,7 +52,7 @@ static ERR_STRING_DATA TPM2TSS_f[] = {
     ERR_F(tpm2tss_tpm2data_write),
     ERR_F(tpm2tss_tpm2data_read),
     ERR_F(tpm2tss_tpm2data_readtpm),
-    ERR_F(init_tpm_primary),
+    ERR_F(init_tpm_parent),
     ERR_F(init_tpm_key),
     /* tpm2-tss-engine-ecc.c */
     ERR_F(ecdsa_sign),

--- a/src/tpm2-tss-engine-err.h
+++ b/src/tpm2-tss-engine-err.h
@@ -77,7 +77,7 @@ void ERR_error(int function, int reason, const char *file, int line);
 #define TPM2TSS_F_tpm2tss_tpm2data_write        110
 #define TPM2TSS_F_tpm2tss_tpm2data_read         111
 #define TPM2TSS_F_tpm2tss_tpm2data_readtpm      112
-#define TPM2TSS_F_init_tpm_primary      113
+#define TPM2TSS_F_init_tpm_parent      113
 #define TPM2TSS_F_init_tpm_key          114
 /* tpm2-tss-engine-ecc.c */
 #define TPM2TSS_F_ecdsa_sign    120

--- a/test/rsasign_parent.sh
+++ b/test/rsasign_parent.sh
@@ -1,0 +1,40 @@
+#!/bin/bash
+
+set -eufx
+
+export OPENSSL_ENGINES=${PWD}/.libs
+export LD_LIBRARY_PATH=$OPENSSL_ENGINES:${LD_LIBRARY_PATH-}
+export PATH=${PWD}:${PATH}
+
+DIR=$(mktemp -d)
+echo -n "abcde12345abcde12345">${DIR}/mydata.txt
+
+# Create an Primary key pair
+echo "Generating primary key"
+PARENT_CTX=${DIR}/primary_owner_key.ctx
+
+tpm2_startup -T mssim -c || true
+
+tpm2_createprimary -T mssim -a o -g sha256 -G rsa -o ${PARENT_CTX}
+tpm2_flushcontext -T mssim -t
+
+# Load primary key to persistent handle
+HANDLE=$(tpm2_evictcontrol -T mssim -a o -c ${PARENT_CTX} | cut -d ' ' -f 2)
+tpm2_flushcontext -T mssim -t
+
+# Generating a key underneath the persistent parent
+tpm2tss-genkey -a rsa -s 2048 -p abc -P ${HANDLE} ${DIR}/mykey
+
+echo "abc" | openssl rsa -engine tpm2tss -inform engine -in ${DIR}/mykey -pubout -outform pem -out ${DIR}/mykey.pub -passin stdin
+cat ${DIR}/mykey.pub
+
+echo "abc" | openssl pkeyutl -engine tpm2tss -keyform engine -inkey ${DIR}/mykey -sign -in ${DIR}/mydata.txt -out ${DIR}/mysig -passin stdin
+
+cat ${DIR}/mysig
+
+#this is a workaround because -verify allways exits 1
+R="$(openssl pkeyutl -pubin -inkey ${DIR}/mykey.pub -verify -in ${DIR}/mydata.txt -sigfile ${DIR}/mysig || true)"
+if ! echo $R | grep "Signature Verified Successfully" >/dev/null; then
+    echo $R
+    exit 1
+fi

--- a/test/rsasign_persistent.sh
+++ b/test/rsasign_persistent.sh
@@ -13,6 +13,8 @@ echo -n "abcde12345abcde12345">${DIR}/mydata.txt
 echo "Generating primary key"
 PARENT_CTX=${DIR}/primary_owner_key.ctx
 
+tpm2_startup -T mssim -c || true
+
 tpm2_createprimary -T mssim -a o -g sha256 -G rsa -o ${PARENT_CTX}
 tpm2_flushcontext -T mssim -t
 


### PR DESCRIPTION
All keys can now be created as children of an existing persistent parent key using the -P parameter.

Fixes: #36 