### PR TITLE
Fixes for PR #55

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -108,7 +108,7 @@ AS_IF([test -z "$PANDOC"],
 AM_CONDITIONAL([HAVE_PANDOC],[test -n "$PANDOC"])
 
 AC_PATH_PROG([EXPECT], [expect])
-AS_IF([test -z "$PANDOC"],
+AS_IF([test -z "$EXPECT"],
     [AC_MSG_WARN([Required executable expect not found, some tests might fail])])
 
 AC_ARG_WITH([enginesdir], 

--- a/src/tpm2-tss-engine-common.c
+++ b/src/tpm2-tss-engine-common.c
@@ -179,7 +179,7 @@ tpm2tss_tpm2data_readtpm(uint32_t handle, TPM2_DATA **tpm2Datap)
     /* If the persistent key has the NODA flag set, we check whether it does
        have an empty authValue. If NODA is not set, then we don't check because
        that would increment the DA lockout counter */
-    if ((outPublic->publicArea.objectAttributes | TPMA_OBJECT_NODA) != 0) {
+    if ((outPublic->publicArea.objectAttributes & TPMA_OBJECT_NODA) != 0) {
         TPMT_SYM_DEF sym = {.algorithm = TPM2_ALG_AES,
                             .keyBits = {.aes = 128},
                             .mode = {.aes = TPM2_ALG_CFB}


### PR DESCRIPTION
- The condition `outPublic->publicArea.objectAttributes | TPMA_OBJECT_NODA) != 0` introduced in #55 is tautologically true because `TPMA_OBJECT_NODA` is nonzero. To test whether `TPMA_OBJECT_NODA` is set, we need <code>outPublic->publicArea.objectAttributes *&* TPMA_OBJECT_NODA) != 0</code> instead.
- Fix a copy&paste error in the configure check for `expect`.