### PR TITLE
tests: use tpm2-tools commands from released version instead of master

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -81,7 +81,7 @@ install:
   - rm ${PWD}/../installdir/usr/local/lib/*.la
   - popd
 # tpm2-tools
-  - git clone --depth=1 https://github.com/tpm2-software/tpm2-tools.git
+  - git clone --depth=1 -b 3.X https://github.com/tpm2-software/tpm2-tools.git
   - pushd tpm2-tools
   - mkdir m4 || true
   - cp ../autoconf-archive-2017.09.28/m4/ax_code_coverage.m4 m4/

--- a/test/rsasign_persistent.sh
+++ b/test/rsasign_persistent.sh
@@ -6,6 +6,8 @@ export OPENSSL_ENGINES=${PWD}/.libs
 export LD_LIBRARY_PATH=$OPENSSL_ENGINES:${LD_LIBRARY_PATH-}
 export PATH=${PWD}:${PATH}
 
+PHANDLE=0x81010002
+
 DIR=$(mktemp -d)
 echo -n "abcde12345abcde12345">${DIR}/mydata.txt
 
@@ -15,31 +17,27 @@ PARENT_CTX=${DIR}/primary_owner_key.ctx
 
 tpm2_startup -T mssim -c || true
 
-tpm2_createprimary -T mssim -a o -g sha256 -G rsa -o ${PARENT_CTX}
-tpm2_flushcontext -T mssim -t
+tpm2_createprimary -T mssim -H o -g sha256 -G rsa -C ${PARENT_CTX}
 
 # Create an RSA key pair
 echo "Generating RSA key pair"
 TPM_RSA_PUBKEY=${DIR}/rsakey.pub
 TPM_RSA_KEY=${DIR}/rsakey
-tpm2_create -T mssim -p abc -C ${PARENT_CTX} -g sha256 -G rsa -u ${TPM_RSA_PUBKEY} -r ${TPM_RSA_KEY} -A sign\|decrypt\|fixedtpm\|fixedparent\|sensitivedataorigin\|userwithauth\|noda
-tpm2_flushcontext -T mssim -t
+tpm2_create -T mssim -K abc -c ${PARENT_CTX} -g sha256 -G rsa -u ${TPM_RSA_PUBKEY} -r ${TPM_RSA_KEY} -A sign\|decrypt\|fixedtpm\|fixedparent\|sensitivedataorigin\|userwithauth\|noda
 
 # Load Key to persistent handle
 RSA_CTX=${DIR}/rsakey.ctx
-tpm2_load -T mssim -C ${PARENT_CTX} -u ${TPM_RSA_PUBKEY} -r ${TPM_RSA_KEY} -o ${RSA_CTX}
-tpm2_flushcontext -T mssim -t
+tpm2_load -T mssim -c ${PARENT_CTX} -u ${TPM_RSA_PUBKEY} -r ${TPM_RSA_KEY} -C ${RSA_CTX}
 
-HANDLE=$(tpm2_evictcontrol -T mssim -a o -c ${RSA_CTX} | cut -d ' ' -f 2)
-tpm2_flushcontext -T mssim -t
+HANDLE=$(tpm2_evictcontrol -T mssim -A o -c ${RSA_CTX} -S ${PHANDLE} | cut -d ' ' -f 2)
 
 # Signing Data
 echo "abc" | openssl pkeyutl -engine tpm2tss -keyform engine -inkey ${HANDLE} -sign -in ${DIR}/mydata.txt -out ${DIR}/mysig -passin stdin
 # Get public key of handle
-tpm2_readpublic -T mssim -c ${HANDLE} -o ${DIR}/mykey.pem -f pem
+tpm2_readpublic -T mssim -H ${HANDLE} -o ${DIR}/mykey.pem -f pem
 
 # Release persistent HANDLE
-tpm2_evictcontrol -T mssim -a o -c ${HANDLE}
+tpm2_evictcontrol -T mssim -A o -H ${HANDLE} -S ${HANDLE}
 
 R="$(openssl pkeyutl -pubin -inkey ${DIR}/mykey.pem -verify -in ${DIR}/mydata.txt -sigfile ${DIR}/mysig || true)"
 if ! echo $R | grep "Signature Verified Successfully" >/dev/null; then


### PR DESCRIPTION
The tpm2-tss-engine CI pipeline clones the tpm2-tss using the latest tag
(2.1.0) but uses the master branch for the tpm2-tools. Instead let's use
the latest release tag for the tpm2-tools as well so we test against a
stable baseline.

This will also make it easier for users to build tpm2-tss-engine since
can use the tpm2-tss and tpm2-tools packages provided by their distro.

Otherwise will need to build the tpm2-tools from source if they want to
run the tests (i.e: with the make check target).

Most of the changes are just about using different command options but 2
are more significant:

* tpm2_evictcontrol tool requires a persistent handle since since is
  still not able to get the first available vacant persistent handle.

* tpm2_flushcontext is not present in the latest release of the tools
  so contexts can't be explicitly flushed. I don't think this is a big
  issue since the simulator is started just before executing the tests.

Signed-off-by: Javier Martinez Canillas <javierm@redhat.com>