### PR TITLE
Added support for configurable TCTI

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -61,6 +61,7 @@ include_HEADERS = include/tpm2-tss-engine.h
 libtpm2tss_la_SOURCES = src/tpm2-tss-engine.c \
                         src/tpm2-tss-engine-common.c \
                         src/tpm2-tss-engine-common.h \
+                        src/tpm2-tss-engine-tcti.c \
                         src/tpm2-tss-engine-err.c \
                         src/tpm2-tss-engine-err.h \
                         src/tpm2-tss-engine-ecc.c \

--- a/configure.ac
+++ b/configure.ac
@@ -75,6 +75,12 @@ AC_ARG_ENABLE([debug],
 AS_IF([test "x$enable_debug" != "xno"],
       AC_DEFINE_UNQUOTED([DEBUG], [1], ["Debug output enabled"]))
 
+AC_ARG_ENABLE([tctienvvar],
+    [AS_HELP_STRING([--enable-tctienvvar],
+                        [Set the TCTI option from an environment variable])],
+    [AC_DEFINE([ENABLE_TCTIENVVAR], [1])],
+    )
+
 AC_CONFIG_FILES([Makefile])
 
 AX_ADD_COMPILER_FLAG([-std=c99])

--- a/include/tpm2-tss-engine.h
+++ b/include/tpm2-tss-engine.h
@@ -51,7 +51,8 @@ typedef struct {
     };
 } TPM2_DATA;
 
-#define TPM2TSS_SET_OWNERAUTH ENGINE_CMD_BASE
+#define TPM2TSS_SET_OWNERAUTH   ENGINE_CMD_BASE
+#define TPM2TSS_SET_TCTI        (ENGINE_CMD_BASE + 1)
 
 int
 tpm2tss_tpm2data_write(const TPM2_DATA *tpm2data, const char *filename);

--- a/src/tpm2-tss-engine-common.c
+++ b/src/tpm2-tss-engine-common.c
@@ -52,6 +52,51 @@ IMPLEMENT_ASN1_FUNCTIONS(TSSPRIVKEY);
 IMPLEMENT_PEM_write_bio(TSSPRIVKEY, TSSPRIVKEY, TSSPRIVKEY_PEM_STRING, TSSPRIVKEY);
 IMPLEMENT_PEM_read_bio(TSSPRIVKEY, TSSPRIVKEY, TSSPRIVKEY_PEM_STRING, TSSPRIVKEY);
 
+/** Initialize the Auxiliary Esys context
+ *
+ */
+TSS2_RC esys_auxctx_init (ESYS_AUXCONTEXT *eactx_p)
+{
+
+    TSS2_RC r;
+    if (!eactx_p) {
+        ERR(esys_auxctx_init, TPM2TSS_R_GENERAL_FAILURE);
+        r = TSS2_BASE_RC_BAD_REFERENCE;
+    } else {
+        TSS2_TCTI_CONTEXT *tcti_ctx = NULL;
+        r = Esys_Initialize (   &(eactx_p->ectx),
+                                tcti_ctx,
+                                NULL);
+        if (TSS2_RC_SUCCESS != r) {
+            ERR(esys_auxctx_init, TPM2TSS_R_GENERAL_FAILURE);
+        }
+    }
+    return r;
+}
+
+/** Finalize the  Auxiliary Esys context
+ *
+ */
+TSS2_RC esys_auxctx_free (ESYS_AUXCONTEXT *eactx_p)
+{
+    TSS2_RC r;
+    TSS2_TCTI_CONTEXT *tcti_ctx;
+    if (!eactx_p || !(eactx_p->ectx)) {
+        ERR(esys_auxctx_free, TPM2TSS_R_GENERAL_FAILURE);
+        r = TSS2_BASE_RC_BAD_REFERENCE;
+    } else {
+        r = Esys_GetTcti (eactx_p->ectx, &tcti_ctx);
+        if (TSS2_RC_SUCCESS != r) {
+            ERR(esys_auxctx_free, TPM2TSS_R_GENERAL_FAILURE);
+        } else {
+            Esys_Finalize (&(eactx_p->ectx));
+            (void)tcti_ctx;
+            eactx_p->dlhandle = NULL;
+            eactx_p->ectx = NULL;
+        }
+    }
+    return r;
+}
 
 /** Serialize tpm2data onto disk
  *

--- a/src/tpm2-tss-engine-common.h
+++ b/src/tpm2-tss-engine-common.h
@@ -58,8 +58,9 @@ TSS2_RC esys_auxctx_init (ESYS_AUXCONTEXT *eactx_p);
 
 TSS2_RC esys_auxctx_free (ESYS_AUXCONTEXT *eactx_p);
 
-TSS2_RC init_tpm_parent(ESYS_CONTEXT **ctx, uint32_t parentHandle,
-                        ESYS_TR *parent);
+TSS2_RC init_tpm_parent (   ESYS_AUXCONTEXT *eactx_p,
+                            TPM2_HANDLE     parentHandle,
+                            ESYS_TR         *parent);
 
 TSS2_RC init_tpm_key (  ESYS_AUXCONTEXT *eactx_p,
                         ESYS_TR         *keyHandle,

--- a/src/tpm2-tss-engine-common.h
+++ b/src/tpm2-tss-engine-common.h
@@ -60,8 +60,10 @@ TSS2_RC esys_auxctx_free (ESYS_AUXCONTEXT *eactx_p);
 
 TSS2_RC init_tpm_parent(ESYS_CONTEXT **ctx, uint32_t parentHandle,
                         ESYS_TR *parent);
-TSS2_RC init_tpm_key(ESYS_CONTEXT **ctx, ESYS_TR *keyHandle,
-                     TPM2_DATA *tpm2Data);
+
+TSS2_RC init_tpm_key (  ESYS_AUXCONTEXT *eactx_p,
+                        ESYS_TR         *keyHandle,
+                        TPM2_DATA       *tpm2Data);
 
 #define ENGINE_HASH_ALG TPM2_ALG_SHA256
 

--- a/src/tpm2-tss-engine-common.h
+++ b/src/tpm2-tss-engine-common.h
@@ -47,6 +47,17 @@ int init_ecc(ENGINE *e);
 int init_rand(ENGINE *e);
 int init_rsa(ENGINE *e);
 
+typedef void* dl_handle_t;
+
+typedef struct {
+    dl_handle_t     dlhandle;
+    ESYS_CONTEXT    *ectx;
+} ESYS_AUXCONTEXT;
+
+TSS2_RC esys_auxctx_init (ESYS_AUXCONTEXT *eactx_p);
+
+TSS2_RC esys_auxctx_free (ESYS_AUXCONTEXT *eactx_p);
+
 TSS2_RC init_tpm_parent(ESYS_CONTEXT **ctx, uint32_t parentHandle,
                         ESYS_TR *parent);
 TSS2_RC init_tpm_key(ESYS_CONTEXT **ctx, ESYS_TR *keyHandle,

--- a/src/tpm2-tss-engine-common.h
+++ b/src/tpm2-tss-engine-common.h
@@ -49,6 +49,16 @@ int init_rsa(ENGINE *e);
 
 typedef void* dl_handle_t;
 
+TSS2_RC tcti_set_opts (const char *opts);
+
+void tcti_clear_opts (void);
+
+TSS2_RC tcti_get_ctx (  TSS2_TCTI_CONTEXT   **ctx_p,
+                        dl_handle_t         *dlhandle_p);
+
+TSS2_RC tcti_free_ctx ( TSS2_TCTI_CONTEXT   **ctx_p,
+                        dl_handle_t         *dlhandle_p);
+
 typedef struct {
     dl_handle_t     dlhandle;
     ESYS_CONTEXT    *ectx;

--- a/src/tpm2-tss-engine-ecc.c
+++ b/src/tpm2-tss-engine-ecc.c
@@ -166,7 +166,7 @@ ecdsa_sign(const unsigned char *dgst, int dgst_len, const BIGNUM *inv,
 		goto error;
 	}
 
-    r = init_tpm_key (  &(eactx.ectx),
+    r = init_tpm_key (  &eactx,
                         &keyHandle,
                         tpm2Data);
     ERRchktss(ecdsa_sign, r, goto error);

--- a/src/tpm2-tss-engine-ecc.c
+++ b/src/tpm2-tss-engine-ecc.c
@@ -460,7 +460,7 @@ tpm2tss_ecc_genkey(EC_KEY *key, TPMI_ECC_CURVE curve, const char *password,
     } else
         tpm2Data->emptyAuth = 1;
 
-    r = init_tpm_parent (   &(eactx.ectx),
+    r = init_tpm_parent (   &eactx,
                             parentHandle,
                             &parent);
     ERRchktss(tpm2tss_rsa_genkey, r, goto error);

--- a/src/tpm2-tss-engine-err.c
+++ b/src/tpm2-tss-engine-err.c
@@ -68,6 +68,14 @@ static ERR_STRING_DATA TPM2TSS_f[] = {
     ERR_F(rsa_priv_dec),
     ERR_F(tpm2tss_rsa_genkey),
     ERR_F(populate_rsa),
+    /* tpm2-tss-engine-tcti.c */
+    ERR_F(tcti_expand_dlname),
+    ERR_F(tcti_dlopen),
+    ERR_F(tcti_get_init),
+    ERR_F(__tcti_get_ctx),
+    ERR_F(tcti_set_opts),
+    ERR_F(tcti_get_ctx),
+    ERR_F(tcti_free_ctx),
     {0, NULL}
 };
 
@@ -87,6 +95,8 @@ static ERR_STRING_DATA TPM2TSS_r[] = {
     ERR_R(TPM2TSS_R_UNKNOWN_CURVE, Unknown ECC curve),
     ERR_R(TPM2TSS_R_UI_ERROR, User interaction),
     ERR_R(TPM2TSS_R_UNKNOWN_CTRL, Unknown engine ctrl),
+    ERR_R(TPM2TSS_R_DL_OPEN_FAILED, Failed to open TCTI library),
+    ERR_R(TPM2TSS_R_DL_INVALID, The TCTI library is invalid),
     /* TPM/TSS Reasons that are useful to the user */
     ERR_R(TPM2TSS_R_AUTH_FAILURE, Authorization failed),
     ERR_R(TPM2TSS_R_OWNER_AUTH_FAILED, Owner authorization failed),

--- a/src/tpm2-tss-engine-err.c
+++ b/src/tpm2-tss-engine-err.c
@@ -54,6 +54,8 @@ static ERR_STRING_DATA TPM2TSS_f[] = {
     ERR_F(tpm2tss_tpm2data_readtpm),
     ERR_F(init_tpm_parent),
     ERR_F(init_tpm_key),
+    ERR_F(esys_auxctx_init),
+    ERR_F(esys_auxctx_free),
     /* tpm2-tss-engine-ecc.c */
     ERR_F(ecdsa_sign),
     ERR_F(populate_ecc),

--- a/src/tpm2-tss-engine-err.h
+++ b/src/tpm2-tss-engine-err.h
@@ -93,6 +93,14 @@ void ERR_error(int function, int reason, const char *file, int line);
 #define TPM2TSS_F_rsa_priv_dec     141
 #define TPM2TSS_F_tpm2tss_rsa_genkey    142
 #define TPM2TSS_F_populate_rsa          143
+/* tpm2-tss-engine-tcti.c */
+#define TPM2TSS_F_tcti_expand_dlname    150
+#define TPM2TSS_F_tcti_dlopen           151
+#define TPM2TSS_F_tcti_get_init         152
+#define TPM2TSS_F___tcti_get_ctx        153
+#define TPM2TSS_F_tcti_set_opts         154
+#define TPM2TSS_F_tcti_get_ctx          155
+#define TPM2TSS_F_tcti_free_ctx         156
 
 /* Reason codes */
 #define TPM2TSS_R_TPM2DATA_READ_FAILED  100
@@ -110,6 +118,8 @@ void ERR_error(int function, int reason, const char *file, int line);
 #define TPM2TSS_R_UNKNOWN_CURVE         112
 #define TPM2TSS_R_UI_ERROR              113
 #define TPM2TSS_R_UNKNOWN_CTRL          114
+#define TPM2TSS_R_DL_OPEN_FAILED        115
+#define TPM2TSS_R_DL_INVALID            116
 /* TPM/TSS Reasons that are useful to the user */
 #define TPM2TSS_R_AUTH_FAILURE          150
 #define TPM2TSS_R_OWNER_AUTH_FAILED     151

--- a/src/tpm2-tss-engine-err.h
+++ b/src/tpm2-tss-engine-err.h
@@ -79,6 +79,8 @@ void ERR_error(int function, int reason, const char *file, int line);
 #define TPM2TSS_F_tpm2tss_tpm2data_readtpm      112
 #define TPM2TSS_F_init_tpm_parent      113
 #define TPM2TSS_F_init_tpm_key          114
+#define TPM2TSS_F_esys_auxctx_init      115
+#define TPM2TSS_F_esys_auxctx_free      116
 /* tpm2-tss-engine-ecc.c */
 #define TPM2TSS_F_ecdsa_sign    120
 #define TPM2TSS_F_populate_ecc          121

--- a/src/tpm2-tss-engine-rsa.c
+++ b/src/tpm2-tss-engine-rsa.c
@@ -157,7 +157,7 @@ rsa_priv_enc(int flen,
     DBG("Padded digest data (size=%i):\n", digest.size);
     DBGBUF(&digest.buffer[0], digest.size);
 
-    r = init_tpm_key (  &(eactx.ectx),
+    r = init_tpm_key (  &eactx,
                         &keyHandle,
                         tpm2Data);
     ERRchktss(rsa_priv_enc, r, goto error);
@@ -257,7 +257,7 @@ rsa_priv_dec(int flen,
         goto error;
     }
 
-    r = init_tpm_key (  &(eactx.ectx),
+    r = init_tpm_key (  &eactx,
                         &keyHandle,
                         tpm2Data);
     ERRchktss(rsa_priv_dec, r, goto out);

--- a/src/tpm2-tss-engine-rsa.c
+++ b/src/tpm2-tss-engine-rsa.c
@@ -530,7 +530,7 @@ tpm2tss_rsa_genkey(RSA *rsa, int bits, BIGNUM *e, char *password,
     } else
         tpm2Data->emptyAuth = 1;
 
-    r = init_tpm_parent (   &(eactx.ectx),
+    r = init_tpm_parent (   &eactx,
                             parentHandle,
                             &parent);
     ERRchktss(tpm2tss_rsa_genkey, r, goto error);

--- a/src/tpm2-tss-engine-rsa.c
+++ b/src/tpm2-tss-engine-rsa.c
@@ -122,7 +122,7 @@ rsa_priv_enc(int flen,
 
     int ret = 0;
     TSS2_RC r = TSS2_RC_SUCCESS;
-    ESYS_CONTEXT *ectx = NULL;
+    ESYS_AUXCONTEXT eactx = (ESYS_AUXCONTEXT){0};
     ESYS_TR keyHandle = ESYS_TR_NONE;
     TPM2B_DATA label = { .size = 0 };
     TPM2B_PUBLIC_KEY_RSA *sig = NULL;
@@ -157,14 +157,21 @@ rsa_priv_enc(int flen,
     DBG("Padded digest data (size=%i):\n", digest.size);
     DBGBUF(&digest.buffer[0], digest.size);
 
-    r = init_tpm_key(&ectx, &keyHandle, tpm2Data);
+    r = init_tpm_key (  &(eactx.ectx),
+                        &keyHandle,
+                        tpm2Data);
     ERRchktss(rsa_priv_enc, r, goto error);
 
     DBG("Signing (via decrypt operation).\n");
-    r = Esys_RSA_Decrypt(ectx, keyHandle,
-                         ESYS_TR_PASSWORD, ESYS_TR_NONE, ESYS_TR_NONE,
-                         &digest, &inScheme, &label,
-                         &sig);
+    r = Esys_RSA_Decrypt (  eactx.ectx,
+                            keyHandle,
+                            ESYS_TR_PASSWORD,
+                            ESYS_TR_NONE,
+                            ESYS_TR_NONE,
+                            &digest,
+                            &inScheme,
+                            &label,
+                            &sig);
     ERRchktss(rsa_priv_enc, r, goto error);
 
     DBG("Signature done (size=%i):\n", sig->size);
@@ -182,12 +189,12 @@ out:
     free(sig);
     if (keyHandle != ESYS_TR_NONE) {
       if (tpm2Data->privatetype == KEY_TYPE_HANDLE) {
-        Esys_TR_Close(ectx, &keyHandle);
+        Esys_TR_Close (eactx.ectx, &keyHandle);
       } else {
-        Esys_FlushContext(ectx, keyHandle);
+        Esys_FlushContext (eactx.ectx, keyHandle);
       }
     }
-    Esys_Finalize(&ectx);
+    esys_auxctx_free (&eactx);
     return (r == TSS2_RC_SUCCESS)? ret : 0;
 }
 
@@ -224,7 +231,7 @@ rsa_priv_dec(int flen,
     DBGBUF(from, flen);
 
     TSS2_RC r;
-    ESYS_CONTEXT *ectx = NULL;
+    ESYS_AUXCONTEXT eactx = (ESYS_AUXCONTEXT){0};
     ESYS_TR keyHandle = ESYS_TR_NONE;
     TPM2B_DATA label = { .size = 0 };
     TPM2B_PUBLIC_KEY_RSA *message = NULL;
@@ -250,13 +257,20 @@ rsa_priv_dec(int flen,
         goto error;
     }
 
-    r = init_tpm_key(&ectx, &keyHandle, tpm2Data);
+    r = init_tpm_key (  &(eactx.ectx),
+                        &keyHandle,
+                        tpm2Data);
     ERRchktss(rsa_priv_dec, r, goto out);
 
-    r = Esys_RSA_Decrypt(ectx, keyHandle,
-                         ESYS_TR_PASSWORD, ESYS_TR_NONE, ESYS_TR_NONE,
-                         &cipher, &inScheme, &label,
-                         &message);
+    r = Esys_RSA_Decrypt (  eactx.ectx,
+                            keyHandle,
+                            ESYS_TR_PASSWORD,
+                            ESYS_TR_NONE,
+                            ESYS_TR_NONE,
+                            &cipher,
+                            &inScheme,
+                            &label,
+                            &message);
     ERRchktss(rsa_priv_dec, r, goto out);
 
     DBG("Decrypted message (size=%i):\n", message->size);
@@ -274,13 +288,13 @@ out:
     free(message);
     if (keyHandle != ESYS_TR_NONE) {
       if (tpm2Data->privatetype == KEY_TYPE_HANDLE) {
-        Esys_TR_Close(ectx, &keyHandle);
+        Esys_TR_Close (eactx.ectx, &keyHandle);
       } else {
-        Esys_FlushContext(ectx, keyHandle);
+        Esys_FlushContext (eactx.ectx, keyHandle);
       }
     }
 
-    Esys_Finalize(&ectx);
+    esys_auxctx_free (&eactx);
     return (r == TSS2_RC_SUCCESS)? flen : 0;
 }
 
@@ -473,7 +487,7 @@ tpm2tss_rsa_genkey(RSA *rsa, int bits, BIGNUM *e, char *password,
     DBG("Generating RSA key for %i bits keysize.\n", bits);
 
     TSS2_RC r = TSS2_RC_SUCCESS;
-    ESYS_CONTEXT *ectx = NULL;
+    ESYS_AUXCONTEXT eactx = (ESYS_AUXCONTEXT){0};
     ESYS_TR parent = ESYS_TR_NONE;
     TPM2B_PUBLIC *keyPublic = NULL;
     TPM2B_PRIVATE *keyPrivate = NULL;
@@ -516,17 +530,29 @@ tpm2tss_rsa_genkey(RSA *rsa, int bits, BIGNUM *e, char *password,
     } else
         tpm2Data->emptyAuth = 1;
 
-    r = init_tpm_parent(&ectx, parentHandle, &parent);
+    r = init_tpm_parent (   &(eactx.ectx),
+                            parentHandle,
+                            &parent);
     ERRchktss(tpm2tss_rsa_genkey, r, goto error);
 
     tpm2Data->parent = parentHandle;
 
     DBG("Generating the RSA key inside the TPM.\n");
 
-    r = Esys_Create(ectx, parent,
-                    ESYS_TR_PASSWORD, ESYS_TR_NONE, ESYS_TR_NONE,
-                    &inSensitive, &inPublic, &allOutsideInfo, &allCreationPCR,
-                    &keyPrivate, &keyPublic, NULL, NULL, NULL);
+    r = Esys_Create (   eactx.ectx,
+                        parent,
+                        ESYS_TR_PASSWORD,
+                        ESYS_TR_NONE,
+                        ESYS_TR_NONE,
+                        &inSensitive,
+                        &inPublic,
+                        &allOutsideInfo,
+                        &allCreationPCR,
+                        &keyPrivate,
+                        &keyPublic,
+                        NULL,
+                        NULL,
+                        NULL);
     ERRchktss(tpm2tss_rsa_genkey, r, goto error);
 
     DBG("Generated the RSA key inside the TPM.\n");
@@ -554,9 +580,9 @@ end:
     free(keyPublic);
 
     if (parent != ESYS_TR_NONE && !parentHandle)
-        Esys_FlushContext(ectx, parent);
+        Esys_FlushContext (eactx.ectx, parent);
 
-    Esys_Finalize(&ectx);
+    esys_auxctx_free (&eactx);
 
     return (r == TSS2_RC_SUCCESS);
 }

--- a/src/tpm2-tss-engine-tcti.c
+++ b/src/tpm2-tss-engine-tcti.c
@@ -1,0 +1,331 @@
+//**********************************************************************;
+// Copyright (c) 2018, General Electric Company.
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+// 1. Redistributions of source code must retain the above copyright notice,
+// this list of conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright notice,
+// this list of conditions and the following disclaimer in the documentation
+// and/or other materials provided with the distribution.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+// THE POSSIBILITY OF SUCH DAMAGE.
+//**********************************************************************;
+
+#include <stdlib.h>
+#include <stdio.h>
+#include <string.h>
+#include <dlfcn.h>
+
+#include <tss2/tss2_tcti.h>
+#include <openssl/err.h>
+#include <openssl/crypto.h>
+
+#include "tpm2-tss-engine-err.h"
+#include "tpm2-tss-engine-common.h"
+
+#define TMP2TSS_TCTI_NAMEFORMAT "libtss2-tcti-%s.so"
+
+static char*
+tcti_expand_dlname (const char *shortname)
+{
+    char *expanddlname;
+    /*  determine required buffer length and allocate it*/
+    int size = snprintf (NULL,
+                         0,
+                         TMP2TSS_TCTI_NAMEFORMAT,
+                         shortname);
+    if (size <= 0) {
+        ERR(tcti_expand_dlname, TPM2TSS_R_GENERAL_FAILURE);
+        expanddlname = NULL;
+    } else {
+        expanddlname = (char*)OPENSSL_malloc((size_t)(size+1));
+        if (!expanddlname) {
+            ERR(tcti_expand_dlname, ERR_R_MALLOC_FAILURE);
+        } else {
+            int print_size = snprintf (expanddlname,
+                                       (size+1),
+                                       TMP2TSS_TCTI_NAMEFORMAT,
+                                       shortname);
+            if (print_size != size) {
+                ERR(tcti_expand_dlname, TPM2TSS_R_GENERAL_FAILURE);
+                OPENSSL_free(expanddlname);
+                expanddlname = NULL;
+            }
+        }
+    }
+    return expanddlname;
+}
+
+static TSS2_RC
+tcti_dlopen (   const char  *dl_path,
+                dl_handle_t *dlhandle_p)
+{
+    TSS2_RC r;
+    dl_handle_t dlhandle = dlopen(dl_path, RTLD_LAZY);
+    if (dlhandle) {
+        *dlhandle_p = dlhandle;
+        r = TSS2_RC_SUCCESS;
+    } else {
+        char *expanddlname = tcti_expand_dlname(dl_path);
+        if (!expanddlname) {
+            ERR(tcti_dlopen, TPM2TSS_R_GENERAL_FAILURE);
+            r = TSS2_BASE_RC_GENERAL_FAILURE;
+        } else {
+            dlhandle = dlopen(expanddlname, RTLD_LAZY);
+            if (dlhandle) {
+                *dlhandle_p = dlhandle;
+                r = TSS2_RC_SUCCESS;
+            } else {
+                ERR(tcti_dlopen, TPM2TSS_R_DL_OPEN_FAILED);
+                r = TSS2_BASE_RC_BAD_REFERENCE;
+            }
+            OPENSSL_free(expanddlname);
+        }
+    }
+    return r;
+}
+
+/*  Given the handle of a loaded TCTI library, get the pointer to the
+    TCTI-initialization function. */
+static TSS2_RC
+tcti_get_init ( dl_handle_t         dlhandle,
+                TSS2_TCTI_INIT_FUNC *init_p)
+{
+    TSS2_RC r;
+    TSS2_TCTI_INFO_FUNC getinfo =
+        (TSS2_TCTI_INFO_FUNC)dlsym(dlhandle, TSS2_TCTI_INFO_SYMBOL);
+    if (!getinfo) {
+        ERR(tcti_get_init, TPM2TSS_R_DL_INVALID);
+        r = TSS2_BASE_RC_BAD_REFERENCE;
+    } else {
+        const TSS2_TCTI_INFO *info_p = getinfo();
+        *init_p = info_p->init;
+        r = TSS2_RC_SUCCESS;
+    }
+    return r;
+}
+
+static void
+tcti_dlclose (dl_handle_t *dlhandle_p)
+{
+    if (dlhandle_p && *dlhandle_p) {
+#ifndef DISABLE_DLCLOSE
+        dlclose(*dlhandle_p);
+#endif
+        *dlhandle_p = NULL;
+    }
+}
+
+/*
+    Given the TCTI library handle and TCTI configuration string, return the
+    initialized TCTI context.
+
+    NOTE: cfg may be NULL. ctx_p must be non-NULL. dlhandle must be a valid
+    handle that can be passed to dlsym.
+*/
+static TSS2_RC
+__tcti_get_ctx (dl_handle_t         dlhandle,
+                const char          *cfg,
+                TSS2_TCTI_CONTEXT   **ctx_p)
+{
+    TSS2_RC r;
+    TSS2_TCTI_INIT_FUNC init;
+    /*  get the TCTI-initialization function using the library */
+    r = tcti_get_init (dlhandle, &init);
+    if (TPM2_RC_SUCCESS != r) {
+        ERR(__tcti_get_ctx,TPM2TSS_R_GENERAL_FAILURE);
+    } else {
+        /* get the TCTI-context size */
+        TSS2_TCTI_CONTEXT *ctx = NULL;
+        size_t ctx_size = 0;
+        r = init (ctx,
+                  &ctx_size,
+                  cfg);
+        if (TPM2_RC_SUCCESS != r) {
+            ERR(__tcti_get_ctx,TPM2TSS_R_GENERAL_FAILURE);
+        } else {
+            ctx = OPENSSL_malloc (ctx_size);
+            if (NULL == ctx) {
+                ERR(__tcti_get_ctx,ERR_R_MALLOC_FAILURE);
+                r = TSS2_BASE_RC_GENERAL_FAILURE;
+            } else {
+                memset(ctx, 0, ctx_size);
+                r = init (ctx,
+                          &ctx_size,
+                          cfg);
+                if (TPM2_RC_SUCCESS != r) {
+                    /*  Initialization failed: free the buffer */
+                    OPENSSL_free(ctx);
+                    ERR(__tcti_get_ctx,TPM2TSS_R_GENERAL_FAILURE);
+                } else {
+                    *ctx_p = ctx;
+                }
+            }
+        }
+    }
+    return r;
+}
+
+static const char *tcti_path = NULL;
+static const char *tcti_cfg = NULL;
+
+void
+tcti_clear_opts (void)
+{
+    OPENSSL_free((void*)tcti_path);
+    tcti_path = NULL;
+    tcti_cfg = NULL;
+}
+
+/*
+    Copy and parse the opts string into the TCTI library path and TCTI
+    configuration.
+
+    NOTE: opts may be NULL.
+*/
+TSS2_RC
+tcti_set_opts (const char *opts)
+{
+    /*  Valid opts may be one of the following:
+        case A: NULL         --> path=NULL,      cfg=NULL
+        case B: \0           --> path=\0,        cfg=NULL
+        case C: path\0       --> path=path\0,    cfg=NULL
+        case D: path:\0      --> path=path\0,    cfg=\0
+        case E: path:cfg\0   --> path=path\0,    cfg=cfg\0
+
+        Following opts are invalid (cfg without path. must be explicitly
+        handled, because dlopen("") returns handle of main program):
+        case F: :\0          --> path=\0,        cfg=\0
+        case G: :cfg\0       --> path=\0,        cfg=\0
+     */
+    TSS2_RC r;
+    char *path, *cfg;
+
+    if (!opts) {
+        /* case A */
+        path = NULL;
+        cfg = NULL;
+        r = TSS2_RC_SUCCESS;
+    } else {
+        path = (char*)OPENSSL_strdup(opts);
+        if (!path) {
+            ERR(tcti_set_opts, ERR_R_MALLOC_FAILURE);
+            r = TSS2_BASE_RC_MEMORY;
+        } else {
+            char *split = strchr(path, (int)':');
+            if (!split) {
+                /* case  B and case C */
+                cfg = NULL;
+                r = TSS2_RC_SUCCESS;
+            } else {
+                if (split==path) {
+                    /* case F and case G */
+                    ERR(tcti_set_opts, TPM2TSS_R_GENERAL_FAILURE);
+                    /* Invalid opts: free the buffer */
+                    OPENSSL_free(path);
+                    r = TSS2_BASE_RC_BAD_REFERENCE;
+                } else {
+                    /* case D and case E */
+                    split[0] = '\0';
+                    cfg = split+1;
+                    r = TSS2_RC_SUCCESS;
+                }
+            }
+        }
+    }
+    /*  set output variables on success */
+    if (TSS2_RC_SUCCESS == r) {
+        tcti_path = path;
+        tcti_cfg = cfg;
+    }
+    return r;
+}
+
+/** get a TCTI context
+ *
+ * Allocate and initialize a TCTI context and associated DL handle.
+ * @param opts          The TCTI option string.
+ * @param ctx_p         The TCTI context output variable
+ * @param dlhandle_p    The DL handle output variable
+ * @retval TSS2_RC_SUCCESS on success or an appropriate TSS2_BASE_RC_ error
+ * code on failure.
+ */
+TSS2_RC
+tcti_get_ctx (  TSS2_TCTI_CONTEXT   **ctx_p,
+                dl_handle_t         *dlhandle_p)
+{
+    TSS2_RC r;
+    if (!ctx_p || !dlhandle_p) {
+        ERR(tcti_get_ctx, ERR_R_PASSED_NULL_PARAMETER);
+        r = TSS2_TCTI_RC_BAD_REFERENCE;
+    } else {
+        if (!tcti_path) {
+            *ctx_p = NULL;
+            *dlhandle_p = NULL;
+            r = TPM2_RC_SUCCESS;
+        } else {
+            /*  open the shared library at path */
+            dl_handle_t dlhandle;
+            r = tcti_dlopen (tcti_path, &dlhandle);
+            if (TPM2_RC_SUCCESS != r) {
+                ERR(tcti_get_ctx, TPM2TSS_R_GENERAL_FAILURE);
+            } else {
+                /*  allocate and initialize the TCTI context */
+                r = __tcti_get_ctx (dlhandle,
+                                    tcti_cfg,
+                                    ctx_p);
+                if (TPM2_RC_SUCCESS == r) {
+                    *dlhandle_p = dlhandle;
+                } else {
+                    /*  Initialize failed: close the TCTI library */
+                    tcti_dlclose(&dlhandle);
+                    ERR(tcti_get_ctx, TPM2TSS_R_GENERAL_FAILURE);
+                }
+            }
+        }
+    }
+    return r;
+}
+
+/** free the TCTI context
+ *
+ * If a TCTI context is initialized, free the allocated memory and set it to
+ * zero. Close the dynamic library for the TCTI module.
+ * @param ctx_p The TCTI context in/out variable.
+ * @retval TSS2_RC_SUCCESS on success or an appropriate TSS2_BASE_RC_ error
+ * code on failure.
+ */
+TSS2_RC
+tcti_free_ctx ( TSS2_TCTI_CONTEXT   **ctx_p,
+                dl_handle_t         *dlhandle_p)
+{
+    TSS2_RC r;
+    if (!ctx_p || !dlhandle_p) {
+        ERR(tcti_free_ctx, ERR_R_PASSED_NULL_PARAMETER);
+        r = TSS2_BASE_RC_BAD_REFERENCE;
+    } else {
+        if (*ctx_p) {
+            Tss2_Tcti_Finalize(*ctx_p);
+            OPENSSL_free(*ctx_p);
+            *ctx_p = NULL;
+            tcti_dlclose(dlhandle_p);
+        }
+        r = TSS2_RC_SUCCESS;
+    }
+    return r;
+}
+

--- a/src/tpm2-tss-engine.c
+++ b/src/tpm2-tss-engine.c
@@ -261,6 +261,18 @@ init_engine(ENGINE *e) {
 
     int rc;
 
+#ifdef ENABLE_TCTIENVVAR
+    /*  Set the default TCTI option from the environment */
+    char *tctienvvar = getenv("TPM2TSSENGINE_TCTI");
+    if (tctienvvar) {
+        tctiopts = OPENSSL_strdup(tctienvvar);
+        if (!tctiopts) {
+            ERR(init_engine, ERR_R_MALLOC_FAILURE);
+            return 0;
+        }
+    }
+#endif
+
     rc = init_rand(e);
     if (rc != 1) {
         ERR(init_engine, TPM2TSS_R_SUBINIT_FAILED);
@@ -293,6 +305,10 @@ static int
 destroy_engine(ENGINE *e)
 {
     (void)(e);
+    if (tctiopts) {
+        OPENSSL_free(tctiopts);
+        tctiopts = NULL;
+    }
     ERR_unload_TPM2TSS_strings();
     return 1;
 }


### PR DESCRIPTION
Previously, the TCTI is configured and freed by `Esys_Initialize` and `Esys_Finalize` based on build-time defaults set in `libtss2-esys` library. The proposed changes allow the TCTI to be configured through engine controls, and optionally, through an environment variable.

This is a rework of PR https://github.com/tpm2-software/tpm2-tss-engine/pull/59 based on previous discussion.