### PR TITLE
Free memory allocated for RSA key components

### DIFF
--- a/src/tpm2-tss-engine-rsa.c
+++ b/src/tpm2-tss-engine-rsa.c
@@ -377,6 +377,23 @@ populate_rsa(RSA *rsa) {
     BIGNUM *iqmp = BN_new();
 
     if (!n || !e || !d || !p || !q || !dmp1 || !dmq1 || !iqmp) {
+        if (n)
+            BN_free(n);
+        if (e)
+            BN_free(e);
+        if (d)
+            BN_free(d);
+        if (p)
+            BN_free(p);
+        if (q)
+            BN_free(q);
+        if (dmp1)
+            BN_free(dmp1);
+        if (dmq1)
+            BN_free(dmq1);
+        if (iqmp)
+            BN_free(iqmp);
+
         ERR(populate_rsa, ERR_R_MALLOC_FAILURE);
         goto error;
     }


### PR DESCRIPTION
Code fails to free partially allocated components of the RSA key in the
error path.

If a BIGNUM other than the first one(BN *n) fails to allocate memory,
the error path does not free allocated memory of the other components.
This issue occurs only for OpenSSL versions > 1.1.x

Signed-off-by: Raghu Krishnamurthy <raghu.ncstate@icloud.com>