### PR TITLE
ECDSA truncation and s_server test

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -109,7 +109,8 @@ TESTS_SHELL = test/ecdsa.sh \
               test/failwrite.sh \
               test/rsasign_parent.sh \
               test/rsasign_persistent.sh \
-              test/rsasign_persistent_emptyauth.sh
+              test/rsasign_persistent_emptyauth.sh \
+              test/sserver.sh
 EXTRA_DIST += $(TESTS_SHELL)
 
 check_PROGRAMS = $(TESTS_UNIT)

--- a/src/tpm2-tss-engine-ecc.c
+++ b/src/tpm2-tss-engine-ecc.c
@@ -142,6 +142,20 @@ ecdsa_sign(const unsigned char *dgst, int dgst_len, const BIGNUM *inv,
 
     TPMT_SIG_SCHEME inScheme = { .scheme = TPM2_ALG_ECDSA };
 
+    /* ECDSA says to truncate the incoming hash to fit the curve. */
+    switch (tpm2Data->pub.publicArea.parameters.eccDetail.curveID) {
+    case TPM2_ECC_NIST_P256:
+        if (dgst_len > 256/8)
+            dgst_len = 256/8;
+        break;
+    case TPM2_ECC_NIST_P384:
+        if (dgst_len > 384/8)
+            dgst_len = 384/8;
+        break;
+    default:
+        break;
+    }
+
     TPM2B_DIGEST digest = { .size = dgst_len };
     if (digest.size > sizeof(digest.buffer)) {
         ERR(rsa_priv_enc, TPM2TSS_R_DIGEST_TOO_LARGE);

--- a/test/sserver.sh
+++ b/test/sserver.sh
@@ -1,0 +1,36 @@
+#!/bin/bash
+
+set -eufx
+
+export LANG=C
+export OPENSSL_ENGINES=${PWD}/.libs
+export LD_LIBRARY_PATH=$OPENSSL_ENGINES:${LD_LIBRARY_PATH-}
+export PATH=${PWD}:${PATH}
+#The following is for DESTDIR-installations of openssl
+export OPENSSL_CONF=$(find $(dirname $(which openssl))/../../ -name openssl.cnf | head -n 1)
+
+if openssl version | grep "OpenSSL 1.0.2" >/dev/null; then
+    echo "OpenSSL 1.0.2 does not load the certificate; private key mismatch ???"
+    exit 77
+fi
+
+DIR=$(mktemp -d)
+
+echo -n "WORKING !!!">${DIR}/index.html
+
+function cleanup()
+{
+    kill -term $SERVER
+}
+
+tpm2tss-genkey -a ecdsa ${DIR}/mykey
+
+echo -e "\n\n\n\n\n\n\n" | openssl req -new -x509 -engine tpm2tss -key ${DIR}/mykey  -keyform engine -out ${DIR}/mykey.crt
+
+openssl s_server -www -cert ${DIR}/mykey.crt -key ${DIR}/mykey -keyform engine -engine tpm2tss -accept 127.0.0.1:8443 &
+SERVER=$!
+trap "cleanup" EXIT
+
+sleep 1
+
+echo "GET index.html" | openssl s_client -connect localhost:8443


### PR DESCRIPTION
Implements truncation for ECDSA and adds an s_server test.
This test only works with OpenSSL 1.1.0 for some reason.

Addresses: #15 
Addresses: #31 

@dwmw2 Could you test this against your setup from #15 again ?

Does anybody know, why OpenSSL 1.0.2 attempts to compare private keys of the certificate ?
The error you get indicates such a behaviour...