### PR TITLE
Remove Esys_Startup from code

### DIFF
--- a/src/tpm2-tss-engine-common.c
+++ b/src/tpm2-tss-engine-common.c
@@ -224,13 +224,6 @@ tpm2tss_tpm2data_readtpm(uint32_t handle, TPM2_DATA **tpm2Datap)
         goto error;
     }
 
-    r = Esys_Startup(eactx.ectx, TPM2_SU_CLEAR);
-    if (r == TPM2_RC_INITIALIZE)
-        DBG("TPM was already started up thus false positive failing in tpm2tss"
-            " log.\n");
-    else
-        ERRchktss(tpm2tss_tpm2data_readtpm, r, goto error);
-
     r = Esys_TR_FromTPMPublic(eactx.ectx, tpm2Data->handle,
                               ESYS_TR_NONE, ESYS_TR_NONE, ESYS_TR_NONE,
                               &keyHandle);
@@ -443,13 +436,6 @@ init_tpm_parent(ESYS_AUXCONTEXT *eactx_p,
     r = esys_auxctx_init(eactx_p);
     ERRchktss(init_tpm_parent, r, goto error);
 
-    r = Esys_Startup(eactx_p->ectx, TPM2_SU_CLEAR);
-    if (r == TPM2_RC_INITIALIZE)
-        DBG("TPM was already started up thus false positive failing in tpm2tss"
-            " log.\n");
-    else
-        ERRchktss(init_tpm_parent, r, goto error);
-
     if (parentHandle && parentHandle != TPM2_RH_OWNER) {
         DBG("Connecting to a persistent parent key.\n");
         r = Esys_TR_FromTPMPublic(eactx_p->ectx, parentHandle,
@@ -508,13 +494,6 @@ init_tpm_key (ESYS_AUXCONTEXT *eactx_p, ESYS_TR *keyHandle, TPM2_DATA *tpm2Data)
         DBG("Establishing connection with TPM.\n");
         r = esys_auxctx_init(eactx_p);
         ERRchktss(init_tpm_key, r, goto error);
-
-        r = Esys_Startup(eactx_p->ectx, TPM2_SU_CLEAR);
-        if (r == TPM2_RC_INITIALIZE)
-            DBG("TPM was already started up thus false positive failing in tpm2tss"
-                " log.\n");
-        else
-            ERRchktss(init_tpm_key, r, goto error);
 
         r = Esys_TR_FromTPMPublic(eactx_p->ectx, tpm2Data->handle,
                                   ESYS_TR_NONE, ESYS_TR_NONE, ESYS_TR_NONE,

--- a/src/tpm2-tss-engine-rand.c
+++ b/src/tpm2-tss-engine-rand.c
@@ -56,12 +56,6 @@ rand_bytes(unsigned char *buf, int num)
     r = esys_auxctx_init(&eactx);
     ERRchktss(rand_bytes, r, goto end);
 
-    r = Esys_Startup(eactx.ectx, TPM2_SU_CLEAR);
-    if (r == TPM2_RC_INITIALIZE)
-        DBG("TPM already started up. False positive error in tpm2tss log.\n");
-    else
-        ERRchktss(rand_bytes, r, goto end);
-
     TPM2B_DIGEST *b;
     while (num > 0) {
         r = Esys_GetRandom(eactx.ectx,

--- a/test/ecdsa-emptyauth.sh
+++ b/test/ecdsa-emptyauth.sh
@@ -9,6 +9,9 @@ export PATH=${PWD}:${PATH}
 
 DIR=$(mktemp -d)
 echo -n "abcde12345abcde12345">${DIR}/mydata
+
+tpm2_startup -T mssim -c || true
+
 tpm2tss-genkey -a ecdsa -c nist_p256 ${DIR}/mykey
 
 openssl pkeyutl -keyform engine -engine tpm2tss -inkey ${DIR}/mykey -sign -in ${DIR}/mydata -out ${DIR}/mysig

--- a/test/ecdsa.sh
+++ b/test/ecdsa.sh
@@ -9,6 +9,9 @@ export PATH=${PWD}:${PATH}
 
 DIR=$(mktemp -d)
 echo -n "abcde12345abcde12345">${DIR}/mydata
+
+tpm2_startup -T mssim -c || true
+
 tpm2tss-genkey -a ecdsa -c nist_p256 -p abc ${DIR}/mykey
 
 echo "abc" | openssl pkeyutl -keyform engine -engine tpm2tss -inkey ${DIR}/mykey -sign -in ${DIR}/mydata -out ${DIR}/mysig -passin stdin

--- a/test/failload.sh
+++ b/test/failload.sh
@@ -10,6 +10,9 @@ export PATH=${PWD}:${PATH}
 DIR=$(mktemp -d)
 echo -n "abcde12345abcde12345">${DIR}/mykey
 chmod ugo-rwx ${DIR}/mykey
+
+tpm2_startup -T mssim -c || true
+
 R="$(openssl rsa -engine tpm2tss -inform engine -in ${DIR}/mykey -pubout -outform pem -out ${DIR}/mykey.pub 2>&1 || true)"
 echo $R
 if ! echo $R | grep "unable to load Private Key" >/dev/null; then

--- a/test/failwrite.sh
+++ b/test/failwrite.sh
@@ -10,6 +10,9 @@ export PATH=${PWD}:${PATH}
 DIR=$(mktemp -d)
 echo -n "abcde12345abcde12345">${DIR}/mykey
 chmod ugo-rwx ${DIR}/mykey
+
+tpm2_startup -T mssim -c || true
+
 R="$(tpm2tss-genkey -a ecdsa -c nist_p256 -p abc ${DIR}/mykey 2>&1 || true)"
 echo $R
 if ! echo $R | grep "Error writing file" >/dev/null; then

--- a/test/rand.sh
+++ b/test/rand.sh
@@ -6,4 +6,6 @@ export OPENSSL_ENGINES=${PWD}/.libs
 export LD_LIBRARY_PATH=$OPENSSL_ENGINES:${LD_LIBRARY_PATH-}
 export PATH=${PWD}:${PATH}
 
+tpm2_startup -T mssim -c || true
+
 openssl rand -engine tpm2tss -hex 10 >/dev/null

--- a/test/rsadecrypt.sh
+++ b/test/rsadecrypt.sh
@@ -8,6 +8,9 @@ export PATH=${PWD}:${PATH}
 
 DIR=$(mktemp -d)
 echo -n "abcde12345abcde12345">${DIR}/mydata
+
+tpm2_startup -T mssim -c || true
+
 tpm2tss-genkey -a rsa -s 2048 -p abc ${DIR}/mykey
 
 echo "abc" | openssl rsa -engine tpm2tss -inform engine -in ${DIR}/mykey -pubout -outform pem -out ${DIR}/mykey.pub -passin stdin

--- a/test/rsasign.sh
+++ b/test/rsasign.sh
@@ -8,6 +8,9 @@ export PATH=${PWD}:${PATH}
 
 DIR=$(mktemp -d)
 echo -n "abcde12345abcde12345">${DIR}/mydata
+
+tpm2_startup -T mssim -c || true
+
 tpm2tss-genkey -a rsa -s 2048 -p abc ${DIR}/mykey
 
 echo "abc" | openssl rsa -engine tpm2tss -inform engine -in ${DIR}/mykey -pubout -outform pem -out ${DIR}/mykey.pub -passin stdin


### PR DESCRIPTION
Esys_Startup clutters the log with many errors.
A TPM should be assumed to be started up when used.
The test scripts will use tpm2-tools to start up the TPM in case
it wasn't.

Fixes: #58 