### PR TITLE
Update tests to also run on physical TPMs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,7 @@ env:
   - OPENSSL_BRANCH=OpenSSL_1_0_2-stable
   - OPENSSL_BRANCH=OpenSSL_1_1_0-stable
   global:
+  - TPM2TOOLS_TCTI=mssim
   - PATH="${PWD}/installdir/usr/local/bin:${PATH}"
   - PKG_CONFIG_PATH="${PWD}/installdir/usr/local/lib/pkgconfig:/usr/lib/pkgconfig"
   - LD_LIBRARY_PATH="${PWD}/installdir/usr/local/lib:/usr/lib"

--- a/src/tpm2-tss-engine-common.c
+++ b/src/tpm2-tss-engine-common.c
@@ -275,7 +275,7 @@ tpm2tss_tpm2data_readtpm(uint32_t handle, TPM2_DATA **tpm2Datap)
 
         r = Esys_ReadPublic(eactx.ectx, keyHandle,
                             session, ESYS_TR_NONE, ESYS_TR_NONE,
-                            &outPublic, NULL, NULL);
+                            NULL, NULL, NULL);
 
         /* tpm2-tss < 2.2 has some bugs. (1) it may miscalculate the auth from
            above leading to a password query in case of empty auth and (2) it

--- a/test/ecdsa-emptyauth.sh
+++ b/test/ecdsa-emptyauth.sh
@@ -10,7 +10,7 @@ export PATH=${PWD}:${PATH}
 DIR=$(mktemp -d)
 echo -n "abcde12345abcde12345">${DIR}/mydata
 
-tpm2_startup -T mssim -c || true
+tpm2_startup -c || true
 
 tpm2tss-genkey -a ecdsa -c nist_p256 ${DIR}/mykey
 

--- a/test/ecdsa.sh
+++ b/test/ecdsa.sh
@@ -10,7 +10,7 @@ export PATH=${PWD}:${PATH}
 DIR=$(mktemp -d)
 echo -n "abcde12345abcde12345">${DIR}/mydata
 
-tpm2_startup -T mssim -c || true
+tpm2_startup -c || true
 
 tpm2tss-genkey -a ecdsa -c nist_p256 -p abc ${DIR}/mykey
 

--- a/test/failload.sh
+++ b/test/failload.sh
@@ -11,7 +11,7 @@ DIR=$(mktemp -d)
 echo -n "abcde12345abcde12345">${DIR}/mykey
 chmod ugo-rwx ${DIR}/mykey
 
-tpm2_startup -T mssim -c || true
+tpm2_startup -c || true
 
 R="$(openssl rsa -engine tpm2tss -inform engine -in ${DIR}/mykey -pubout -outform pem -out ${DIR}/mykey.pub 2>&1 || true)"
 echo $R

--- a/test/failwrite.sh
+++ b/test/failwrite.sh
@@ -11,7 +11,7 @@ DIR=$(mktemp -d)
 echo -n "abcde12345abcde12345">${DIR}/mykey
 chmod ugo-rwx ${DIR}/mykey
 
-tpm2_startup -T mssim -c || true
+tpm2_startup -c || true
 
 R="$(tpm2tss-genkey -a ecdsa -c nist_p256 -p abc ${DIR}/mykey 2>&1 || true)"
 echo $R

--- a/test/rand.sh
+++ b/test/rand.sh
@@ -6,6 +6,6 @@ export OPENSSL_ENGINES=${PWD}/.libs
 export LD_LIBRARY_PATH=$OPENSSL_ENGINES:${LD_LIBRARY_PATH-}
 export PATH=${PWD}:${PATH}
 
-tpm2_startup -T mssim -c || true
+tpm2_startup -c || true
 
 openssl rand -engine tpm2tss -hex 10 >/dev/null

--- a/test/rsadecrypt.sh
+++ b/test/rsadecrypt.sh
@@ -9,7 +9,7 @@ export PATH=${PWD}:${PATH}
 DIR=$(mktemp -d)
 echo -n "abcde12345abcde12345">${DIR}/mydata
 
-tpm2_startup -T mssim -c || true
+tpm2_startup -c || true
 
 tpm2tss-genkey -a rsa -s 2048 -p abc ${DIR}/mykey
 

--- a/test/rsasign.sh
+++ b/test/rsasign.sh
@@ -9,7 +9,7 @@ export PATH=${PWD}:${PATH}
 DIR=$(mktemp -d)
 echo -n "abcde12345abcde12345">${DIR}/mydata
 
-tpm2_startup -T mssim -c || true
+tpm2_startup -c || true
 
 tpm2tss-genkey -a rsa -s 2048 -p abc ${DIR}/mykey
 

--- a/test/rsasign_parent.sh
+++ b/test/rsasign_parent.sh
@@ -13,14 +13,14 @@ echo -n "abcde12345abcde12345">${DIR}/mydata.txt
 echo "Generating primary key"
 PARENT_CTX=${DIR}/primary_owner_key.ctx
 
-tpm2_startup -T mssim -c || true
+tpm2_startup -c || true
 
-tpm2_createprimary -T mssim -a o -g sha256 -G rsa -o ${PARENT_CTX}
-tpm2_flushcontext -T mssim -t
+tpm2_createprimary -a o -g sha256 -G rsa -o ${PARENT_CTX}
+tpm2_flushcontext -t
 
 # Load primary key to persistent handle
-HANDLE=$(tpm2_evictcontrol -T mssim -a o -c ${PARENT_CTX} | cut -d ' ' -f 2)
-tpm2_flushcontext -T mssim -t
+HANDLE=$(tpm2_evictcontrol -a o -c ${PARENT_CTX} | cut -d ' ' -f 2)
+tpm2_flushcontext -t
 
 # Generating a key underneath the persistent parent
 tpm2tss-genkey -a rsa -s 2048 -p abc -P ${HANDLE} ${DIR}/mykey
@@ -31,7 +31,7 @@ cat ${DIR}/mykey.pub
 echo "abc" | openssl pkeyutl -engine tpm2tss -keyform engine -inkey ${DIR}/mykey -sign -in ${DIR}/mydata.txt -out ${DIR}/mysig -passin stdin
 
 # Release persistent HANDLE
-tpm2_evictcontrol -T mssim -a o -c ${HANDLE} -p ${HANDLE}
+tpm2_evictcontrol -a o -c ${HANDLE} -p ${HANDLE}
 
 cat ${DIR}/mysig
 

--- a/test/rsasign_persistent.sh
+++ b/test/rsasign_persistent.sh
@@ -13,33 +13,33 @@ echo -n "abcde12345abcde12345">${DIR}/mydata.txt
 echo "Generating primary key"
 PARENT_CTX=${DIR}/primary_owner_key.ctx
 
-tpm2_startup -T mssim -c || true
+tpm2_startup -c || true
 
-tpm2_createprimary -T mssim -a o -g sha256 -G rsa -o ${PARENT_CTX}
-tpm2_flushcontext -T mssim -t
+tpm2_createprimary -a o -g sha256 -G rsa -o ${PARENT_CTX}
+tpm2_flushcontext -t
 
 # Create an RSA key pair
 echo "Generating RSA key pair"
 TPM_RSA_PUBKEY=${DIR}/rsakey.pub
 TPM_RSA_KEY=${DIR}/rsakey
-tpm2_create -T mssim -p abc -C ${PARENT_CTX} -g sha256 -G rsa -u ${TPM_RSA_PUBKEY} -r ${TPM_RSA_KEY} -A sign\|decrypt\|fixedtpm\|fixedparent\|sensitivedataorigin\|userwithauth\|noda
-tpm2_flushcontext -T mssim -t
+tpm2_create -p abc -C ${PARENT_CTX} -g sha256 -G rsa -u ${TPM_RSA_PUBKEY} -r ${TPM_RSA_KEY} -A sign\|decrypt\|fixedtpm\|fixedparent\|sensitivedataorigin\|userwithauth\|noda
+tpm2_flushcontext -t
 
 # Load Key to persistent handle
 RSA_CTX=${DIR}/rsakey.ctx
-tpm2_load -T mssim -C ${PARENT_CTX} -u ${TPM_RSA_PUBKEY} -r ${TPM_RSA_KEY} -o ${RSA_CTX}
-tpm2_flushcontext -T mssim -t
+tpm2_load -C ${PARENT_CTX} -u ${TPM_RSA_PUBKEY} -r ${TPM_RSA_KEY} -o ${RSA_CTX}
+tpm2_flushcontext -t
 
-HANDLE=$(tpm2_evictcontrol -T mssim -a o -c ${RSA_CTX} | cut -d ' ' -f 2)
-tpm2_flushcontext -T mssim -t
+HANDLE=$(tpm2_evictcontrol -a o -c ${RSA_CTX} | cut -d ' ' -f 2)
+tpm2_flushcontext -t
 
 # Signing Data
 echo "abc" | openssl pkeyutl -engine tpm2tss -keyform engine -inkey ${HANDLE} -sign -in ${DIR}/mydata.txt -out ${DIR}/mysig -passin stdin
 # Get public key of handle
-tpm2_readpublic -T mssim -c ${HANDLE} -o ${DIR}/mykey.pem -f pem
+tpm2_readpublic -c ${HANDLE} -o ${DIR}/mykey.pem -f pem
 
 # Release persistent HANDLE
-tpm2_evictcontrol -T mssim -a o -c ${HANDLE}
+tpm2_evictcontrol -a o -c ${HANDLE}
 
 R="$(openssl pkeyutl -pubin -inkey ${DIR}/mykey.pem -verify -in ${DIR}/mydata.txt -sigfile ${DIR}/mysig || true)"
 if ! echo $R | grep "Signature Verified Successfully" >/dev/null; then

--- a/test/rsasign_persistent_emptyauth.sh
+++ b/test/rsasign_persistent_emptyauth.sh
@@ -13,25 +13,25 @@ echo -n "abcde12345abcde12345">${DIR}/mydata.txt
 echo "Generating primary key"
 PARENT_CTX=${DIR}/primary_owner_key.ctx
 
-tpm2_startup -T mssim -c || true
+tpm2_startup -c || true
 
-tpm2_createprimary -T mssim -a o -g sha256 -G rsa -o ${PARENT_CTX}
-tpm2_flushcontext -T mssim -t
+tpm2_createprimary -a o -g sha256 -G rsa -o ${PARENT_CTX}
+tpm2_flushcontext -t
 
 # Create an RSA key pair
 echo "Generating RSA key pair"
 TPM_RSA_PUBKEY=${DIR}/rsakey.pub
 TPM_RSA_KEY=${DIR}/rsakey
-tpm2_create -T mssim -C ${PARENT_CTX} -g sha256 -G rsa -u ${TPM_RSA_PUBKEY} -r ${TPM_RSA_KEY} -A sign\|decrypt\|fixedtpm\|fixedparent\|sensitivedataorigin\|userwithauth\|noda
-tpm2_flushcontext -T mssim -t
+tpm2_create -C ${PARENT_CTX} -g sha256 -G rsa -u ${TPM_RSA_PUBKEY} -r ${TPM_RSA_KEY} -A sign\|decrypt\|fixedtpm\|fixedparent\|sensitivedataorigin\|userwithauth\|noda
+tpm2_flushcontext -t
 
 # Load Key to persistent handle
 RSA_CTX=${DIR}/rsakey.ctx
-tpm2_load -T mssim -C ${PARENT_CTX} -u ${TPM_RSA_PUBKEY} -r ${TPM_RSA_KEY} -o ${RSA_CTX}
-tpm2_flushcontext -T mssim -t
+tpm2_load -C ${PARENT_CTX} -u ${TPM_RSA_PUBKEY} -r ${TPM_RSA_KEY} -o ${RSA_CTX}
+tpm2_flushcontext -t
 
-HANDLE=$(tpm2_evictcontrol -T mssim -a o -c ${RSA_CTX} | cut -d ' ' -f 2)
-tpm2_flushcontext -T mssim -t
+HANDLE=$(tpm2_evictcontrol -a o -c ${RSA_CTX} | cut -d ' ' -f 2)
+tpm2_flushcontext -t
 
 # Signing Data
 #Actually signing should not require an auth value
@@ -46,10 +46,10 @@ EOF
 fi
 
 # Get public key of handle
-tpm2_readpublic -T mssim -c ${HANDLE} -o ${DIR}/mykey.pem -f pem
+tpm2_readpublic -c ${HANDLE} -o ${DIR}/mykey.pem -f pem
 
 # Release persistent HANDLE
-tpm2_evictcontrol -T mssim -a o -c ${HANDLE} -p ${HANDLE}
+tpm2_evictcontrol -a o -c ${HANDLE} -p ${HANDLE}
 
 R="$(openssl pkeyutl -pubin -inkey ${DIR}/mykey.pem -verify -in ${DIR}/mydata.txt -sigfile ${DIR}/mysig || true)"
 if ! echo $R | grep "Signature Verified Successfully" >/dev/null; then


### PR DESCRIPTION
TCTI for tests were hard-coded to use the simulator. Removing
"-T mssim" will instruct TPM-Tools to iterate through all available
TCTI interfaces instead.