### PR TITLE
build: install existing man pages even if pandoc is not available

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -145,20 +145,22 @@ AUTHORS:
 EXTRA_DIST += AUTHORS
 CLEANFILES += AUTHORS
 
-if HAVE_PANDOC
+if HAVE_MAN_PAGES
 ### Man Pages
 man1_MANS = \
-    man/tpm2tss-genkey.1
+    man/man1/tpm2tss-genkey.1
 man3_MANS = \
-    man/tpm2tss_tpm2data_write.3 \
-    man/tpm2tss_rsa_makekey.3 \
-    man/tpm2tss_rsa_genkey.3 \
-    man/tpm2tss_ecc_makekey.3 \
-    man/tpm2tss_ecc_genkey.3 \
-    man/tpm2tss_ecc_getappdata.3 \
-    man/tpm2tss_tpm2data_read.3 \
-    man/tpm2tss_ecc_setappdata.3
+    man/man3/tpm2tss_tpm2data_write.3 \
+    man/man3/tpm2tss_rsa_makekey.3 \
+    man/man3/tpm2tss_rsa_genkey.3 \
+    man/man3/tpm2tss_ecc_makekey.3 \
+    man/man3/tpm2tss_ecc_genkey.3 \
+    man/man3/tpm2tss_ecc_getappdata.3 \
+    man/man3/tpm2tss_tpm2data_read.3 \
+    man/man3/tpm2tss_ecc_setappdata.3
+endif
 
+if HAVE_PANDOC
 # If pandoc is enabled, we want to generate the manpages for the dist tarball
 EXTRA_DIST += \
     $(man1_MANS) \
@@ -172,21 +174,17 @@ dist-hook:
 	@exit 1
 endif
 
-define man_dir
-    mkdir man 2>/dev/null || test -d man
-endef
-
-man/tpm2tss_tpm2data_read.3: man/tpm2tss_tpm2data_write.3
+man/man3/tpm2tss_tpm2data_read.3: man/man3/tpm2tss_tpm2data_write.3
 	$(AM_V_GEN)(rm $@ 2>/dev/null || true) && ln -s tpm2tss_tpm2data_write.3 $@
 
-man/tpm2tss_ecc_setappdata.3: man/tpm2tss_ecc_getappdata.3
+man/man3/tpm2tss_ecc_setappdata.3: man/man3/tpm2tss_ecc_getappdata.3
 	$(AM_V_GEN)(rm $@ 2>/dev/null || true) && ln -s tpm2tss_ecc_getappdata.3 $@
 
-man/%.1: man/%.1.md
-	$(AM_V_GEN)$(call man_dir) && cat $< | $(PANDOC) -s -t man >$@
+man/man1/%.1: man/%.1.md
+	$(AM_V_GEN)mkdir -p man/man1 && cat $< | $(PANDOC) -s -t man >$@
 
-man/%.3: man/%.3.md
-	$(AM_V_GEN)$(call man_dir) && cat $< | $(PANDOC) -s -t man >$@
+man/man3/%.3: man/%.3.md
+	$(AM_V_GEN)mkdir -p man/man3 && cat $< | $(PANDOC) -s -t man >$@
 
 EXTRA_DIST += \
     man/tpm2tss-genkey.1.md \

--- a/configure.ac
+++ b/configure.ac
@@ -118,6 +118,7 @@ AC_PATH_PROG([PANDOC], [pandoc])
 AS_IF([test -z "$PANDOC"],
     [AC_MSG_WARN([Required executable pandoc not found, man pages will not be built])])
 AM_CONDITIONAL([HAVE_PANDOC],[test -n "$PANDOC"])
+AM_CONDITIONAL([HAVE_MAN_PAGES],[test -d "${srcdir}/man/man1" -o -n "$PANDOC"])
 
 AC_PATH_PROG([EXPECT], [expect])
 AS_IF([test -z "$EXPECT"],


### PR DESCRIPTION
Currently man pages are only installed if pandoc is available on the system. Since release tarballs already include the generated man pages, the dependency on pandoc can be avoided on the target system. To do so, use the solution from tpm2-tools to have a conditional [`HAVE_MAN_PAGES`](https://github.com/tpm2-software/tpm2-tools/blob/bd188cb7fc9985081eb8b931f80d196f594539fc/configure.ac#L23) that tracks whether the folder with the generated man pages already exists.