### PR TITLE
configure.ac: calling --disable-tctienvvar will set ENABLE_TCTIENVVAR to 1

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -67,8 +67,7 @@ AC_PROG_LN_S
 
 AC_ARG_ENABLE([debug],
             [AS_HELP_STRING([--enable-debug],
-                            [build with debug output (default is no)])],
-            [enable_debug=$enableval],
+                            [build with debug output])],,
             [enable_debug=no])
 AS_IF([test "x$enable_debug" != "xno"],
       AC_DEFINE_UNQUOTED([DEBUG], [1], ["Debug output enabled"]))
@@ -146,8 +145,7 @@ AC_SUBST(completionsdir, "$with_completionsdir")
 
 AC_ARG_ENABLE([unit],
             [AS_HELP_STRING([--enable-unit],
-                            [build cmocka unit tests (default is no)])],
-            [enable_unit=$enableval],
+                            [build cmocka unit tests])],,
             [enable_unit=no])
 AS_IF([test "x$enable_unit" != "xno" ], 
       [PKG_CHECK_MODULES([CMOCKA], [cmocka >= 1.0])])
@@ -155,8 +153,7 @@ AM_CONDITIONAL([UNIT], [test "x$enable_unit" != xno])
 
 AC_ARG_ENABLE([integration],
             [AS_HELP_STRING([--enable-integration],
-                            [build integration tests against TPM (default is no)])],
-            [enable_integration=$enableval],
+                            [build integration tests against TPM])],,
             [enable_integration=no])
 AM_CONDITIONAL([INTEGRATION], [test "x$enable_integration" != xno])
 

--- a/configure.ac
+++ b/configure.ac
@@ -75,9 +75,8 @@ AS_IF([test "x$enable_debug" != "xno"],
 
 AC_ARG_ENABLE([tctienvvar],
     [AS_HELP_STRING([--enable-tctienvvar],
-                        [Set the TCTI option from an environment variable])],
-    [AC_DEFINE([ENABLE_TCTIENVVAR], [1])],
-    )
+                        [Set the TCTI option from an environment variable])])
+AS_IF([test "x$enable_tctienvvar" = xyes], [AC_DEFINE([ENABLE_TCTIENVVAR], [1])])
 
 AC_CONFIG_FILES([Makefile])
 

--- a/configure.ac
+++ b/configure.ac
@@ -36,9 +36,6 @@ AC_INIT([tpm2-tss-engine],
         [],
         [https://github.com/tpm2-software/tpm2-tss-engine])
 
-dnl Avoid setting CFLAGS to anything by default; we use AC_CFLAGS below for this.
-: ${CFLAGS=""}
-
 dnl Let's be FHS-conform by default.
 if test "$prefix" = '/usr'; then
     test "$sysconfdir" = '${prefix}/etc' && sysconfdir="/etc"


### PR DESCRIPTION
Tweaks for configue.ac:
* Remove `: ${CFLAGS=""}` to preserve the default behavior of ./configure
* Ensure `./configure --disable-tctienvvar` does not set ENABLE_TCTIENVVAR to 1
* When `./configure --help` prints --enable-X, this impies that the feature is disabled by default, so do not emit in addition “(default is on)”