### PR TITLE
Bump required tpm2-tss to 2.2.2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,9 +8,8 @@ dist: trusty
 
 env:
   matrix:
-  - OPENSSL_BRANCH=OpenSSL_1_0_2-stable TPM2TSS_BRANCH=2.2.0
-  - OPENSSL_BRANCH=OpenSSL_1_1_0-stable TPM2TSS_BRANCH=2.1.0
-  - OPENSSL_BRANCH=OpenSSL_1_1_0-stable TPM2TSS_BRANCH=2.2.0
+  - OPENSSL_BRANCH=OpenSSL_1_0_2-stable TPM2TSS_BRANCH=2.2.x
+  - OPENSSL_BRANCH=OpenSSL_1_1_0-stable TPM2TSS_BRANCH=2.2.x
   global:
   - TPM2TOOLS_TCTI=mssim
   - PATH="${PWD}/installdir/usr/local/bin:${PATH}"

--- a/Makefile.am
+++ b/Makefile.am
@@ -123,7 +123,8 @@ TESTS_SHELL = test/ecdsa.sh \
               test/rsasign_parent.sh \
               test/rsasign_persistent.sh \
               test/rsasign_persistent_emptyauth.sh \
-              test/sserver.sh
+              test/sserver.sh \
+              test/sclient.sh
 EXTRA_DIST += $(TESTS_SHELL)
 
 if UNIT

--- a/configure.ac
+++ b/configure.ac
@@ -111,9 +111,7 @@ AX_ADD_AM_MACRO_STATIC([])
 PKG_PROG_PKG_CONFIG([0.25])
 PKG_CHECK_MODULES([CRYPTO], [libcrypto >= 1.0.2g],
                   [ac_enginesdir=`$PKG_CONFIG --variable=enginesdir libcrypto`])
-PKG_CHECK_MODULES([TSS2_ESYS], [tss2-esys >= 2.2],
-                  [AC_DEFINE(TSS22, [1], ["tpm2tss version >= 2.2"])],
-                  [PKG_CHECK_MODULES([TSS2_ESYS],[tss2-esys])])
+PKG_CHECK_MODULES([TSS2_ESYS], [tss2-esys >= 2.2])
 
 AC_PATH_PROG([PANDOC], [pandoc])
 AS_IF([test -z "$PANDOC"],

--- a/configure.ac
+++ b/configure.ac
@@ -111,7 +111,7 @@ AX_ADD_AM_MACRO_STATIC([])
 PKG_PROG_PKG_CONFIG([0.25])
 PKG_CHECK_MODULES([CRYPTO], [libcrypto >= 1.0.2g],
                   [ac_enginesdir=`$PKG_CONFIG --variable=enginesdir libcrypto`])
-PKG_CHECK_MODULES([TSS2_ESYS], [tss2-esys >= 2.2])
+PKG_CHECK_MODULES([TSS2_ESYS], [tss2-esys >= 2.2.2])
 
 AC_PATH_PROG([PANDOC], [pandoc])
 AS_IF([test -z "$PANDOC"],

--- a/src/tpm2-tss-engine-common.c
+++ b/src/tpm2-tss-engine-common.c
@@ -241,7 +241,6 @@ tpm2tss_tpm2data_readtpm(uint32_t handle, TPM2_DATA **tpm2Datap)
         goto error;
     }
 
-#ifdef TSS22
     /* If the persistent key has the NODA flag set, we check whether it does
        have an empty authValue. If NODA is not set, then we don't check because
        that would increment the DA lockout counter */
@@ -308,7 +307,6 @@ tpm2tss_tpm2data_readtpm(uint32_t handle, TPM2_DATA **tpm2Datap)
     }
 
 session_error:
-#endif /* TSS22 */
 
     Esys_TR_Close(eactx.ectx, &keyHandle);
 

--- a/test/sclient.sh
+++ b/test/sclient.sh
@@ -1,0 +1,54 @@
+#!/bin/bash
+
+set -eufx
+
+export LANG=C
+export OPENSSL_ENGINES=${PWD}/.libs
+export LD_LIBRARY_PATH=$OPENSSL_ENGINES:${LD_LIBRARY_PATH-}
+export PATH=${PWD}:${PATH}
+#The following is for DESTDIR-installations of openssl
+export OPENSSL_CONF=$(find $(dirname $(which openssl))/../../ -name openssl.cnf | head -n 1)
+
+if openssl version | grep "OpenSSL 1.0.2" >/dev/null; then
+    echo "OpenSSL 1.0.2 does not load the certificate; private key mismatch ???"
+    exit 77
+fi
+
+DIR=$(mktemp -d)
+
+echo -en "SSL CONNECTION WORKING\n">${DIR}/test.html
+
+function cleanup()
+{
+    kill -term $SERVER || true
+}
+
+openssl ecparam -genkey -name prime256v1 -noout -out ${DIR}/ca.key
+
+echo -e "\n\n\n\n\n\n\n" | openssl req -new -x509 -batch -extensions v3_ca -key ${DIR}/ca.key -out ${DIR}/ca.crt
+
+echo -e "\n\n\n\n\n\n\n\n\n" | openssl req -new -newkey rsa:2048 -nodes -keyout ${DIR}/server.key -out ${DIR}/server.csr
+
+openssl x509 -req -in ${DIR}/server.csr -CA ${DIR}/ca.crt -CAkey ${DIR}/ca.key -CAcreateserial -out ${DIR}/server.crt
+
+tpm2tss-genkey -a rsa ${DIR}/client.tpm.key
+
+echo -e "\n\n\n\n\n\n\n\n\n" | openssl req -new -key ${DIR}/client.tpm.key -keyform engine -engine tpm2tss -out ${DIR}/client.csr
+
+openssl x509 -req -in ${DIR}/client.csr -CA ${DIR}/ca.crt -CAkey ${DIR}/ca.key -CAcreateserial -out ${DIR}/client.crt
+
+pushd ${DIR}
+openssl s_server -cert ${DIR}/server.crt -key ${DIR}/server.key -accept 8443 -verify 1 -CAfile ${DIR}/ca.crt -WWW &
+SERVER=$!
+popd
+
+sleep 1
+
+kill -0 $!
+
+trap "cleanup" EXIT
+
+# We have to sleep, such that the pipe stays open until the command is finished.
+(echo -e "GET /test.html HTTP/1.1\r\n\r\n" && sleep 1) | openssl s_client -connect 127.0.0.1:8443 -cert ${DIR}/client.crt -key ${DIR}/client.tpm.key -engine tpm2tss -keyform engine -CAfile ${DIR}/ca.crt
+
+echo "SUCCESS"


### PR DESCRIPTION
- Require tpm2-tss 2.2.2 since that makes openssl s_client work
- Remove special handling of tpm2-tss 2.1.x regarding noda checking of persistent keys
- Add test for openssl s_client

Fixes: #93 