### PR TITLE
Add OpenSSL 1.1.1 to CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,7 @@ env:
   matrix:
   - OPENSSL_BRANCH=OpenSSL_1_0_2-stable TPM2TSS_BRANCH=2.2.x
   - OPENSSL_BRANCH=OpenSSL_1_1_0-stable TPM2TSS_BRANCH=2.2.x
+  - OPENSSL_BRANCH=OpenSSL_1_1_1-stable TPM2TSS_BRANCH=2.2.x
   global:
   - TPM2TOOLS_TCTI=mssim
   - PATH="${PWD}/installdir/usr/local/bin:${PATH}"


### PR DESCRIPTION
Add the branch openssl_1.1.1-stable to .travis.yml for CI testing.

Signed-off-by: Andreas Fuchs <andreas.fuchs@sit.fraunhofer.de>