### PR TITLE
Use a TPM simulator for the integration tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -112,8 +112,6 @@ before_script:
 
 script:
 # build with all tests enabled
-  - tpm_server &
-  - sleep 1
   - CONFIGURE_OPTIONS="CFLAGS=-I${PWD}/installdir/usr/local/include LDFLAGS=-L${PWD}/installdir/usr/local/lib "
   - ./bootstrap
   - mkdir ./build

--- a/.travis.yml
+++ b/.travis.yml
@@ -124,10 +124,10 @@ script:
     fi
   - $SCAN_PREFIX ../configure $CONFIGURE_OPTIONS --enable-unit --enable-integration
   - $SCAN_PREFIX make -j$(nproc)
-  - make -j1 check
+  - make -j$(nproc) check
   - cat test-suite.log config.log
   - ../configure $CONFIGURE_OPTIONS
-  - make -j1 distcheck
+  - make -j$(nproc) distcheck
   - cat config.log
   - popd
 

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -12,6 +12,9 @@
 * tpm2-tss >= 2.2.2
 * pandoc
 * expect
+* tpm_server
+* realpath
+* ss
 
 ## Ubuntu
 ```
@@ -26,7 +29,9 @@ sudo apt -y install \
   pkg-config \
   libssl-dev \
   pandoc \
-  expect
+  expect \
+  realpath \
+  ss
 git clone -b 2.2.x --depth=1 http://www.github.com/tpm2-software/tpm2-tss
 cd tpm2-tss
 ./bootstrap

--- a/Makefile.am
+++ b/Makefile.am
@@ -122,6 +122,9 @@ TESTS_SHELL = test/ecdsa.sh \
               test/sserver.sh \
               test/sclient.sh
 EXTRA_DIST += $(TESTS_SHELL)
+TEST_EXTENSIONS = .sh
+SH_LOG_COMPILER = $(srcdir)/test/sh_log_compiler.sh
+EXTRA_DIST += $(SH_LOG_COMPILER)
 
 if UNIT
 TESTS_UNIT += test/error_tpm2-tss-engine-common

--- a/README.md
+++ b/README.md
@@ -140,19 +140,12 @@ OpenSSL 1.1.0 and newer.
 ## Development prefixes
 In order to use this engine without `make install` for testing call:
 ```
-export LD_LIBRAY_PATH=${TPM2TSS}/src/tss2-{tcti,mu,sys,esys}/.libs:${PWD}/.libs
-export OPENSSL_ENGINES=${PWD}/.libs
-export PATH=${PWD}:${PATH}
+export LD_LIBRAY_PATH=${TPM2TSS}/src/tss2-{tcti,mu,sys,esys}/.libs
 export PKG_CONFIG_PATH=$PWD/../tpm2-tss/lib
 ./bootstrap
 ./configure \
     CFLAGS="-I$PWD/../tpm2-tss/include" \
     LDFLAGS="-L$PWD/../tpm2-tss/src/tss2-{esys,sys,mu,tcti}/.libs"
 make
-tpm_server
 make check
 ```
-make check will use any available TPM (including /dev/tpm0,
-/dev/tpmrm0) at this moment, until ESAPI allows runtime configuration of TCTI.
-
-PRECONDITION for tests: The owner password of the TPM must be set to zero.

--- a/configure.ac
+++ b/configure.ac
@@ -159,6 +159,17 @@ AS_IF([test "x$enable_integration" = xyes],
       [AC_CHECK_PROG([tpm2_startup], [tpm2_startup], [yes])
        AS_IF([test "x$tpm2_startup" != xyes],
              [AC_MSG_ERROR([Integration tests require the tpm2_startup executable])])
+       AC_CHECK_PROG([tpm_server], [tpm_server], [yes])
+       AS_IF([test "x$tpm_server" != xyes],
+             [AC_MSG_ERROR([Integration tests require the tpm_server executable])])
+       AC_CHECK_PROG([realpath], [realpath], [yes])
+       AS_IF([test "x$realpath" != xyes],
+             [AC_MSG_ERROR([Integration tests require the realpath executable])])
+       AC_CHECK_PROG([ss], [ss], [yes])
+       AS_IF([test "x$ss" != xyes],
+             [AC_MSG_ERROR([Integration tests require the ss executable])])
+       AS_IF([test "x$enable_tctienvvar" != xyes],
+             [AC_MSG_ERROR([Integration tests require building with TCTI environment variable support])])
       ])
 
 AC_OUTPUT

--- a/configure.ac
+++ b/configure.ac
@@ -73,8 +73,9 @@ AS_IF([test "x$enable_debug" != "xno"],
       AC_DEFINE_UNQUOTED([DEBUG], [1], ["Debug output enabled"]))
 
 AC_ARG_ENABLE([tctienvvar],
-    [AS_HELP_STRING([--enable-tctienvvar],
-                        [Set the TCTI option from an environment variable])])
+    [AS_HELP_STRING([--disable-tctienvvar],
+                    [Disable setting the TCTI option from an environment variable])],,
+    [enable_tctienvvar=yes])
 AS_IF([test "x$enable_tctienvvar" = xyes], [AC_DEFINE([ENABLE_TCTIENVVAR], [1])])
 
 AC_CONFIG_FILES([Makefile])

--- a/test/ecdsa-emptyauth.sh
+++ b/test/ecdsa-emptyauth.sh
@@ -2,21 +2,13 @@
 
 set -eufx
 
-export LANG=C
-if [ -z "${OPENSSL_ENGINES-}" ]; then export OPENSSL_ENGINES=${PWD}/.libs; fi
-export LD_LIBRARY_PATH=$OPENSSL_ENGINES:${LD_LIBRARY_PATH-}
-export PATH=${PWD}:${PATH}
+echo -n "abcde12345abcde12345">mydata
 
-DIR=$(mktemp -d)
-echo -n "abcde12345abcde12345">${DIR}/mydata
+tpm2tss-genkey -a ecdsa -c nist_p256 mykey
 
-tpm2_startup -c || true
+openssl pkeyutl -keyform engine -engine tpm2tss -inkey mykey -sign -in mydata -out mysig
 
-tpm2tss-genkey -a ecdsa -c nist_p256 ${DIR}/mykey
-
-openssl pkeyutl -keyform engine -engine tpm2tss -inkey ${DIR}/mykey -sign -in ${DIR}/mydata -out ${DIR}/mysig
-
-R="$(openssl pkeyutl -keyform engine -engine tpm2tss -inkey ${DIR}/mykey -verify -in ${DIR}/mydata -sigfile ${DIR}/mysig || true)"
+R="$(openssl pkeyutl -keyform engine -engine tpm2tss -inkey mykey -verify -in mydata -sigfile mysig || true)"
 if ! echo $R | grep "Signature Verified Successfully" >/dev/null; then
     echo $R
     exit 1

--- a/test/failload.sh
+++ b/test/failload.sh
@@ -2,18 +2,10 @@
 
 set -eufx
 
-export LANG=C
-if [ -z "${OPENSSL_ENGINES-}" ]; then export OPENSSL_ENGINES=${PWD}/.libs; fi
-export LD_LIBRARY_PATH=$OPENSSL_ENGINES:${LD_LIBRARY_PATH-}
-export PATH=${PWD}:${PATH}
+echo -n "abcde12345abcde12345">mykey
+chmod ugo-rwx mykey
 
-DIR=$(mktemp -d)
-echo -n "abcde12345abcde12345">${DIR}/mykey
-chmod ugo-rwx ${DIR}/mykey
-
-tpm2_startup -c || true
-
-R="$(openssl rsa -engine tpm2tss -inform engine -in ${DIR}/mykey -pubout -outform pem -out ${DIR}/mykey.pub 2>&1 || true)"
+R="$(openssl rsa -engine tpm2tss -inform engine -in mykey -pubout -outform pem -out mykey.pub 2>&1 || true)"
 echo $R
 if ! echo $R | grep "unable to load Private Key" >/dev/null; then
     exit 1

--- a/test/failwrite.sh
+++ b/test/failwrite.sh
@@ -2,18 +2,10 @@
 
 set -eufx
 
-export LANG=C
-if [ -z "${OPENSSL_ENGINES-}" ]; then export OPENSSL_ENGINES=${PWD}/.libs; fi
-export LD_LIBRARY_PATH=$OPENSSL_ENGINES:${LD_LIBRARY_PATH-}
-export PATH=${PWD}:${PATH}
+echo -n "abcde12345abcde12345">mykey
+chmod ugo-rwx mykey
 
-DIR=$(mktemp -d)
-echo -n "abcde12345abcde12345">${DIR}/mykey
-chmod ugo-rwx ${DIR}/mykey
-
-tpm2_startup -c || true
-
-R="$(tpm2tss-genkey -a ecdsa -c nist_p256 -p abc ${DIR}/mykey 2>&1 || true)"
+R="$(tpm2tss-genkey -a ecdsa -c nist_p256 -p abc mykey 2>&1 || true)"
 echo $R
 if ! echo $R | grep "Error writing file" >/dev/null; then
     exit 1

--- a/test/rand.sh
+++ b/test/rand.sh
@@ -2,10 +2,4 @@
 
 set -eufx
 
-if [ -z "${OPENSSL_ENGINES-}" ]; then export OPENSSL_ENGINES=${PWD}/.libs; fi
-export LD_LIBRARY_PATH=$OPENSSL_ENGINES:${LD_LIBRARY_PATH-}
-export PATH=${PWD}:${PATH}
-
-tpm2_startup -c || true
-
 openssl rand -engine tpm2tss -hex 10 >/dev/null

--- a/test/rsasign_parent.sh
+++ b/test/rsasign_parent.sh
@@ -2,18 +2,11 @@
 
 set -eufx
 
-if [ -z "${OPENSSL_ENGINES-}" ]; then export OPENSSL_ENGINES=${PWD}/.libs; fi
-export LD_LIBRARY_PATH=$OPENSSL_ENGINES:${LD_LIBRARY_PATH-}
-export PATH=${PWD}:${PATH}
-
-DIR=$(mktemp -d)
-echo -n "abcde12345abcde12345">${DIR}/mydata.txt
+echo -n "abcde12345abcde12345">mydata.txt
 
 # Create an Primary key pair
 echo "Generating primary key"
-PARENT_CTX=${DIR}/primary_owner_key.ctx
-
-tpm2_startup -c || true
+PARENT_CTX=primary_owner_key.ctx
 
 tpm2_createprimary -a o -g sha256 -G rsa -o ${PARENT_CTX}
 tpm2_flushcontext -t
@@ -23,20 +16,20 @@ HANDLE=$(tpm2_evictcontrol -a o -c ${PARENT_CTX} | cut -d ' ' -f 2)
 tpm2_flushcontext -t
 
 # Generating a key underneath the persistent parent
-tpm2tss-genkey -a rsa -s 2048 -p abc -P ${HANDLE} ${DIR}/mykey
+tpm2tss-genkey -a rsa -s 2048 -p abc -P ${HANDLE} mykey
 
-echo "abc" | openssl rsa -engine tpm2tss -inform engine -in ${DIR}/mykey -pubout -outform pem -out ${DIR}/mykey.pub -passin stdin
-cat ${DIR}/mykey.pub
+echo "abc" | openssl rsa -engine tpm2tss -inform engine -in mykey -pubout -outform pem -out mykey.pub -passin stdin
+cat mykey.pub
 
-echo "abc" | openssl pkeyutl -engine tpm2tss -keyform engine -inkey ${DIR}/mykey -sign -in ${DIR}/mydata.txt -out ${DIR}/mysig -passin stdin
+echo "abc" | openssl pkeyutl -engine tpm2tss -keyform engine -inkey mykey -sign -in mydata.txt -out mysig -passin stdin
 
 # Release persistent HANDLE
 tpm2_evictcontrol -a o -c ${HANDLE} -p ${HANDLE}
 
-cat ${DIR}/mysig
+cat mysig
 
 #this is a workaround because -verify allways exits 1
-R="$(openssl pkeyutl -pubin -inkey ${DIR}/mykey.pub -verify -in ${DIR}/mydata.txt -sigfile ${DIR}/mysig || true)"
+R="$(openssl pkeyutl -pubin -inkey mykey.pub -verify -in mydata.txt -sigfile mysig || true)"
 if ! echo $R | grep "Signature Verified Successfully" >/dev/null; then
     echo $R
     exit 1

--- a/test/rsasign_persistent.sh
+++ b/test/rsasign_persistent.sh
@@ -22,7 +22,7 @@ tpm2_flushcontext -t
 echo "Generating RSA key pair"
 TPM_RSA_PUBKEY=${DIR}/rsakey.pub
 TPM_RSA_KEY=${DIR}/rsakey
-tpm2_create -p abc -C ${PARENT_CTX} -g sha256 -G rsa -u ${TPM_RSA_PUBKEY} -r ${TPM_RSA_KEY} -A sign\|decrypt\|fixedtpm\|fixedparent\|sensitivedataorigin\|userwithauth\|noda
+tpm2_create -p abc -C ${PARENT_CTX} -g sha256 -G rsa -u ${TPM_RSA_PUBKEY} -r ${TPM_RSA_KEY} -b sign\|decrypt\|fixedtpm\|fixedparent\|sensitivedataorigin\|userwithauth\|noda
 tpm2_flushcontext -t
 
 # Load Key to persistent handle

--- a/test/rsasign_persistent.sh
+++ b/test/rsasign_persistent.sh
@@ -2,31 +2,24 @@
 
 set -eufx
 
-if [ -z "${OPENSSL_ENGINES-}" ]; then export OPENSSL_ENGINES=${PWD}/.libs; fi
-export LD_LIBRARY_PATH=$OPENSSL_ENGINES:${LD_LIBRARY_PATH-}
-export PATH=${PWD}:${PATH}
-
-DIR=$(mktemp -d)
-echo -n "abcde12345abcde12345">${DIR}/mydata.txt
+echo -n "abcde12345abcde12345">mydata.txt
 
 # Create an Primary key pair
 echo "Generating primary key"
-PARENT_CTX=${DIR}/primary_owner_key.ctx
-
-tpm2_startup -c || true
+PARENT_CTX=primary_owner_key.ctx
 
 tpm2_createprimary -a o -g sha256 -G rsa -o ${PARENT_CTX}
 tpm2_flushcontext -t
 
 # Create an RSA key pair
 echo "Generating RSA key pair"
-TPM_RSA_PUBKEY=${DIR}/rsakey.pub
-TPM_RSA_KEY=${DIR}/rsakey
+TPM_RSA_PUBKEY=rsakey.pub
+TPM_RSA_KEY=rsakey
 tpm2_create -p abc -C ${PARENT_CTX} -g sha256 -G rsa -u ${TPM_RSA_PUBKEY} -r ${TPM_RSA_KEY} -b sign\|decrypt\|fixedtpm\|fixedparent\|sensitivedataorigin\|userwithauth\|noda
 tpm2_flushcontext -t
 
 # Load Key to persistent handle
-RSA_CTX=${DIR}/rsakey.ctx
+RSA_CTX=rsakey.ctx
 tpm2_load -C ${PARENT_CTX} -u ${TPM_RSA_PUBKEY} -r ${TPM_RSA_KEY} -o ${RSA_CTX}
 tpm2_flushcontext -t
 
@@ -34,14 +27,14 @@ HANDLE=$(tpm2_evictcontrol -a o -c ${RSA_CTX} | cut -d ' ' -f 2)
 tpm2_flushcontext -t
 
 # Signing Data
-echo "abc" | openssl pkeyutl -engine tpm2tss -keyform engine -inkey ${HANDLE} -sign -in ${DIR}/mydata.txt -out ${DIR}/mysig -passin stdin
+echo "abc" | openssl pkeyutl -engine tpm2tss -keyform engine -inkey ${HANDLE} -sign -in mydata.txt -out mysig -passin stdin
 # Get public key of handle
-tpm2_readpublic -c ${HANDLE} -o ${DIR}/mykey.pem -f pem
+tpm2_readpublic -c ${HANDLE} -o mykey.pem -f pem
 
 # Release persistent HANDLE
 tpm2_evictcontrol -a o -c ${HANDLE}
 
-R="$(openssl pkeyutl -pubin -inkey ${DIR}/mykey.pem -verify -in ${DIR}/mydata.txt -sigfile ${DIR}/mysig || true)"
+R="$(openssl pkeyutl -pubin -inkey mykey.pem -verify -in mydata.txt -sigfile mysig || true)"
 if ! echo $R | grep "Signature Verified Successfully" >/dev/null; then
     echo $R
     exit 1

--- a/test/rsasign_persistent_emptyauth.sh
+++ b/test/rsasign_persistent_emptyauth.sh
@@ -2,31 +2,24 @@
 
 set -eufx
 
-if [ -z "${OPENSSL_ENGINES-}" ]; then export OPENSSL_ENGINES=${PWD}/.libs; fi
-export LD_LIBRARY_PATH=$OPENSSL_ENGINES:${LD_LIBRARY_PATH-}
-export PATH=${PWD}:${PATH}
-
-DIR=$(mktemp -d)
-echo -n "abcde12345abcde12345">${DIR}/mydata.txt
+echo -n "abcde12345abcde12345">mydata.txt
 
 # Create an Primary key pair
 echo "Generating primary key"
-PARENT_CTX=${DIR}/primary_owner_key.ctx
-
-tpm2_startup -c || true
+PARENT_CTX=primary_owner_key.ctx
 
 tpm2_createprimary -a o -g sha256 -G rsa -o ${PARENT_CTX}
 tpm2_flushcontext -t
 
 # Create an RSA key pair
 echo "Generating RSA key pair"
-TPM_RSA_PUBKEY=${DIR}/rsakey.pub
-TPM_RSA_KEY=${DIR}/rsakey
+TPM_RSA_PUBKEY=rsakey.pub
+TPM_RSA_KEY=rsakey
 tpm2_create -C ${PARENT_CTX} -g sha256 -G rsa -u ${TPM_RSA_PUBKEY} -r ${TPM_RSA_KEY} -b sign\|decrypt\|fixedtpm\|fixedparent\|sensitivedataorigin\|userwithauth\|noda
 tpm2_flushcontext -t
 
 # Load Key to persistent handle
-RSA_CTX=${DIR}/rsakey.ctx
+RSA_CTX=rsakey.ctx
 tpm2_load -C ${PARENT_CTX} -u ${TPM_RSA_PUBKEY} -r ${TPM_RSA_KEY} -o ${RSA_CTX}
 tpm2_flushcontext -t
 
@@ -35,10 +28,10 @@ tpm2_flushcontext -t
 
 # Signing Data
 #Actually signing should not require an auth value
-if ! openssl pkeyutl -engine tpm2tss -keyform engine -inkey ${HANDLE} -sign -in ${DIR}/mydata.txt -out ${DIR}/mysig -passin file:notexists; then
+if ! openssl pkeyutl -engine tpm2tss -keyform engine -inkey ${HANDLE} -sign -in mydata.txt -out mysig -passin file:notexists; then
 #The expect script is only here, because tpm2-tss <2.2 had some bug, and thus us asking for passwords when none were required.
 expect <<EOF
-spawn openssl pkeyutl -engine tpm2tss -keyform engine -inkey ${HANDLE} -sign -in ${DIR}/mydata.txt -out ${DIR}/mysig -passin stdin
+spawn openssl pkeyutl -engine tpm2tss -keyform engine -inkey ${HANDLE} -sign -in mydata.txt -out mysig -passin stdin
 expect "Enter password for user key:"
 send "\r\n"
 expect eof
@@ -46,12 +39,12 @@ EOF
 fi
 
 # Get public key of handle
-tpm2_readpublic -c ${HANDLE} -o ${DIR}/mykey.pem -f pem
+tpm2_readpublic -c ${HANDLE} -o mykey.pem -f pem
 
 # Release persistent HANDLE
 tpm2_evictcontrol -a o -c ${HANDLE} -p ${HANDLE}
 
-R="$(openssl pkeyutl -pubin -inkey ${DIR}/mykey.pem -verify -in ${DIR}/mydata.txt -sigfile ${DIR}/mysig || true)"
+R="$(openssl pkeyutl -pubin -inkey mykey.pem -verify -in mydata.txt -sigfile mysig || true)"
 if ! echo $R | grep "Signature Verified Successfully" >/dev/null; then
     echo $R
     exit 1

--- a/test/rsasign_persistent_emptyauth.sh
+++ b/test/rsasign_persistent_emptyauth.sh
@@ -22,7 +22,7 @@ tpm2_flushcontext -t
 echo "Generating RSA key pair"
 TPM_RSA_PUBKEY=${DIR}/rsakey.pub
 TPM_RSA_KEY=${DIR}/rsakey
-tpm2_create -C ${PARENT_CTX} -g sha256 -G rsa -u ${TPM_RSA_PUBKEY} -r ${TPM_RSA_KEY} -A sign\|decrypt\|fixedtpm\|fixedparent\|sensitivedataorigin\|userwithauth\|noda
+tpm2_create -C ${PARENT_CTX} -g sha256 -G rsa -u ${TPM_RSA_PUBKEY} -r ${TPM_RSA_KEY} -b sign\|decrypt\|fixedtpm\|fixedparent\|sensitivedataorigin\|userwithauth\|noda
 tpm2_flushcontext -t
 
 # Load Key to persistent handle

--- a/test/sclient.sh
+++ b/test/sclient.sh
@@ -2,10 +2,6 @@
 
 set -eufx
 
-export LANG=C
-if [ -z "${OPENSSL_ENGINES-}" ]; then export OPENSSL_ENGINES=${PWD}/.libs; fi
-export LD_LIBRARY_PATH=$OPENSSL_ENGINES:${LD_LIBRARY_PATH-}
-export PATH=${PWD}:${PATH}
 #The following is for DESTDIR-installations of openssl
 export OPENSSL_CONF=$(find $(dirname $(which openssl))/../../ -name openssl.cnf | head -n 1)
 
@@ -14,33 +10,29 @@ if openssl version | grep "OpenSSL 1.0.2" >/dev/null; then
     exit 77
 fi
 
-DIR=$(mktemp -d)
-
-echo -en "SSL CONNECTION WORKING\n">${DIR}/test.html
+echo -en "SSL CONNECTION WORKING\n">test.html
 
 function cleanup()
 {
     kill -term $SERVER || true
 }
 
-openssl ecparam -genkey -name prime256v1 -noout -out ${DIR}/ca.key
+openssl ecparam -genkey -name prime256v1 -noout -out ca.key
 
-echo -e "\n\n\n\n\n\n\n" | openssl req -new -x509 -batch -extensions v3_ca -key ${DIR}/ca.key -out ${DIR}/ca.crt
+echo -e "\n\n\n\n\n\n\n" | openssl req -new -x509 -batch -extensions v3_ca -key ca.key -out ca.crt
 
-echo -e "\n\n\n\n\n\n\n\n\n" | openssl req -new -newkey rsa:2048 -nodes -keyout ${DIR}/server.key -out ${DIR}/server.csr
+echo -e "\n\n\n\n\n\n\n\n\n" | openssl req -new -newkey rsa:2048 -nodes -keyout server.key -out server.csr
 
-openssl x509 -req -in ${DIR}/server.csr -CA ${DIR}/ca.crt -CAkey ${DIR}/ca.key -CAcreateserial -out ${DIR}/server.crt
+openssl x509 -req -in server.csr -CA ca.crt -CAkey ca.key -CAcreateserial -out server.crt
 
-tpm2tss-genkey -a rsa ${DIR}/client.tpm.key
+tpm2tss-genkey -a rsa client.tpm.key
 
-echo -e "\n\n\n\n\n\n\n\n\n" | openssl req -new -key ${DIR}/client.tpm.key -keyform engine -engine tpm2tss -out ${DIR}/client.csr
+echo -e "\n\n\n\n\n\n\n\n\n" | openssl req -new -key client.tpm.key -keyform engine -engine tpm2tss -out client.csr
 
-openssl x509 -req -in ${DIR}/client.csr -CA ${DIR}/ca.crt -CAkey ${DIR}/ca.key -CAcreateserial -out ${DIR}/client.crt
+openssl x509 -req -in client.csr -CA ca.crt -CAkey ca.key -CAcreateserial -out client.crt
 
-pushd ${DIR}
-openssl s_server -cert ${DIR}/server.crt -key ${DIR}/server.key -accept 8443 -verify 1 -CAfile ${DIR}/ca.crt -WWW &
+openssl s_server -cert server.crt -key server.key -accept 8443 -verify 1 -CAfile ca.crt -WWW &
 SERVER=$!
-popd
 
 sleep 1
 
@@ -49,6 +41,6 @@ kill -0 $!
 trap "cleanup" EXIT
 
 # We have to sleep, such that the pipe stays open until the command is finished.
-(echo -e "GET /test.html HTTP/1.1\r\n\r\n" && sleep 1) | openssl s_client -connect 127.0.0.1:8443 -cert ${DIR}/client.crt -key ${DIR}/client.tpm.key -engine tpm2tss -keyform engine -CAfile ${DIR}/ca.crt
+(echo -e "GET /test.html HTTP/1.1\r\n\r\n" && sleep 1) | openssl s_client -connect 127.0.0.1:8443 -cert client.crt -key client.tpm.key -engine tpm2tss -keyform engine -CAfile ca.crt
 
 echo "SUCCESS"

--- a/test/sh_log_compiler.sh
+++ b/test/sh_log_compiler.sh
@@ -1,0 +1,49 @@
+#!/bin/bash
+
+export LANG=C
+export OPENSSL_ENGINES="${OPENSSL_ENGINES:=$PWD/.libs}"
+export LD_LIBRARY_PATH="$OPENSSL_ENGINES:${LD_LIBRARY_PATH-}"
+export PATH="$PWD:$PATH"
+
+test_script="$(realpath "$1")"
+
+tmp_dir="$(mktemp --directory)"
+echo "Switching to temporary directory $tmp_dir"
+cd "$tmp_dir"
+
+for attempt in $(seq 9 -1 0); do
+    tpm_server_port="$(shuf --input-range 1024-65534 --head-count 1)"
+    echo "Starting simulator on port $tpm_server_port"
+    tpm_server -port "$tpm_server_port" &
+    tpm_server_pid="$!"
+    sleep 1
+
+    if ( ss --listening --tcp --ipv4 --processes | grep "$tpm_server_pid" | grep --quiet "$tpm_server_port" &&
+         ss --listening --tcp --ipv4 --processes | grep "$tpm_server_pid" | grep --quiet "$(( tpm_server_port + 1 ))" )
+    then
+        echo "Simulator with PID $tpm_server_pid started successfully"
+        break
+    else
+        echo "Failed to start simulator, the port might be in use"
+        kill "$tpm_server_pid"
+
+        if [ "$attempt" -eq 0 ]; then
+            echo 'ERROR: Reached maximum number of tries to start simulator, giving up'
+            exit 99
+        fi
+    fi
+done
+
+export TPM2TSSENGINE_TCTI="libtss2-tcti-mssim.so:port=$tpm_server_port"
+export TPM2TOOLS_TCTI="$TPM2TSSENGINE_TCTI"
+
+tpm2_startup --clear
+
+echo "Starting $test_script"
+"$test_script"
+test_status="$?"
+
+kill "$tpm_server_pid"
+rm -rf "$tmp_dir"
+
+exit "$test_status"

--- a/test/sserver.sh
+++ b/test/sserver.sh
@@ -2,10 +2,6 @@
 
 set -eufx
 
-export LANG=C
-if [ -z "${OPENSSL_ENGINES-}" ]; then export OPENSSL_ENGINES=${PWD}/.libs; fi
-export LD_LIBRARY_PATH=$OPENSSL_ENGINES:${LD_LIBRARY_PATH-}
-export PATH=${PWD}:${PATH}
 #The following is for DESTDIR-installations of openssl
 export OPENSSL_CONF=$(find $(dirname $(which openssl))/../../ -name openssl.cnf | head -n 1)
 
@@ -14,20 +10,18 @@ if openssl version | grep "OpenSSL 1.0.2" >/dev/null; then
     exit 77
 fi
 
-DIR=$(mktemp -d)
-
-echo -n "WORKING !!!">${DIR}/index.html
+echo -n "WORKING !!!">index.html
 
 function cleanup()
 {
     kill -term $SERVER
 }
 
-tpm2tss-genkey -a ecdsa ${DIR}/mykey
+tpm2tss-genkey -a ecdsa mykey
 
-echo -e "\n\n\n\n\n\n\n" | openssl req -new -x509 -engine tpm2tss -key ${DIR}/mykey  -keyform engine -out ${DIR}/mykey.crt
+echo -e "\n\n\n\n\n\n\n" | openssl req -new -x509 -engine tpm2tss -key mykey  -keyform engine -out mykey.crt
 
-openssl s_server -www -cert ${DIR}/mykey.crt -key ${DIR}/mykey -keyform engine -engine tpm2tss -accept 127.0.0.1:8443 &
+openssl s_server -www -cert mykey.crt -key mykey -keyform engine -engine tpm2tss -accept 127.0.0.1:8443 &
 SERVER=$!
 trap "cleanup" EXIT
 

--- a/test/sserver.sh
+++ b/test/sserver.sh
@@ -21,10 +21,10 @@ tpm2tss-genkey -a ecdsa mykey
 
 echo -e "\n\n\n\n\n\n\n" | openssl req -new -x509 -engine tpm2tss -key mykey  -keyform engine -out mykey.crt
 
-openssl s_server -www -cert mykey.crt -key mykey -keyform engine -engine tpm2tss -accept 127.0.0.1:8443 &
+openssl s_server -www -cert mykey.crt -key mykey -keyform engine -engine tpm2tss -accept 127.0.0.1:8444 &
 SERVER=$!
 trap "cleanup" EXIT
 
 sleep 1
 
-echo "GET index.html" | openssl s_client -connect localhost:8443
+echo "GET index.html" | openssl s_client -connect localhost:8444


### PR DESCRIPTION
Add a simple test harness to automatically start and use a TPM simulator for the integration tests. This is possible by using the TCTI environment variable introduced in #62, which is now enabled by default for this reason.

This has the following advantages:
- Integration tests will run out of the box on any system.
- There is no danger of clobbering data on an existing TPM.
- The tests can be run in parallel.
- The integration test scripts can be simplified because the environment configuration is done globally in the test harness.

Additionally this PR fixes #106 (upstream renaming of tpm2-tools options).

Closes #86
