### PR TITLE
Update things surrounding tpm-tools in tests

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -11,7 +11,11 @@
 * OpenSSL >= 1.0.2
 * tpm2-tss >= 2.2.2
 * pandoc
+
+Integration tests also require:
 * expect
+* tpm2-tools >=4.0 (or master)
+* A TPM or tpm_server (the simulator)
 
 ## Ubuntu
 ```
@@ -25,14 +29,33 @@ sudo apt -y install \
   gcc \
   pkg-config \
   libssl-dev \
-  pandoc \
-  expect
+  pandoc
+
 git clone -b 2.2.x --depth=1 http://www.github.com/tpm2-software/tpm2-tss
 cd tpm2-tss
 ./bootstrap
 ./configure
 make -j$(nproc)
 sudo make install
+```
+
+Integration tests:
+```
+sudo apt -y install \
+  expect
+
+git clone --depth=1 http://github.com/tpm2-software/tpm2-tools
+cd tpm2-tools
+./bootstrap
+./configure
+make -j$(nproc)
+sudo make install
+
+wget https://download.01.org/tpm2/ibmtpm974.tar.gz
+mkdir ibmtpm
+tar axf ibmtpm974.tar.gz -C ibmtpm
+make -C ibmtpm/src -j$(nproc)
+sudo cp ibmtpm/src/tpm_server /usr/local/bin
 ```
 
 # Building from source
@@ -60,6 +83,14 @@ In order to link against a developer version of tpm2-tss (not installed):
   PKG_CONFIG_PATH=${TPM2TSS}/lib:$PKG_CONFIG_PATH \
   CFLAGS=-I${TPM2TSS}/include \
   LDFLAGS=-L${TPM2TSS}/src/tss2-{tcti,mu,sys,esys}/.libs 
+```
+
+## Testing
+In order to build the tests, pass the following options
+(see the additional dependencies above):
+```
+./configure --enable-integration --enable-unit
+make check
 ```
 
 # Post installation

--- a/test/ecdsa-emptyauth.sh
+++ b/test/ecdsa-emptyauth.sh
@@ -10,7 +10,7 @@ export PATH=${PWD}:${PATH}
 DIR=$(mktemp -d)
 echo -n "abcde12345abcde12345">${DIR}/mydata
 
-tpm2_startup -c || true
+tpm2_startup --clear || true
 
 tpm2tss-genkey -a ecdsa -c nist_p256 ${DIR}/mykey
 

--- a/test/ecdsa.sh
+++ b/test/ecdsa.sh
@@ -10,7 +10,7 @@ export PATH=${PWD}:${PATH}
 DIR=$(mktemp -d)
 echo -n "abcde12345abcde12345">${DIR}/mydata
 
-tpm2_startup -c || true
+tpm2_startup --clear || true
 
 tpm2tss-genkey -a ecdsa -c nist_p256 -p abc ${DIR}/mykey
 

--- a/test/failload.sh
+++ b/test/failload.sh
@@ -11,7 +11,7 @@ DIR=$(mktemp -d)
 echo -n "abcde12345abcde12345">${DIR}/mykey
 chmod ugo-rwx ${DIR}/mykey
 
-tpm2_startup -c || true
+tpm2_startup --clear || true
 
 R="$(openssl rsa -engine tpm2tss -inform engine -in ${DIR}/mykey -pubout -outform pem -out ${DIR}/mykey.pub 2>&1 || true)"
 echo $R

--- a/test/failwrite.sh
+++ b/test/failwrite.sh
@@ -11,7 +11,7 @@ DIR=$(mktemp -d)
 echo -n "abcde12345abcde12345">${DIR}/mykey
 chmod ugo-rwx ${DIR}/mykey
 
-tpm2_startup -c || true
+tpm2_startup --clear || true
 
 R="$(tpm2tss-genkey -a ecdsa -c nist_p256 -p abc ${DIR}/mykey 2>&1 || true)"
 echo $R

--- a/test/rand.sh
+++ b/test/rand.sh
@@ -6,6 +6,6 @@ if [ -z "${OPENSSL_ENGINES-}" ]; then export OPENSSL_ENGINES=${PWD}/.libs; fi
 export LD_LIBRARY_PATH=$OPENSSL_ENGINES:${LD_LIBRARY_PATH-}
 export PATH=${PWD}:${PATH}
 
-tpm2_startup -c || true
+tpm2_startup --clear || true
 
 openssl rand -engine tpm2tss -hex 10 >/dev/null

--- a/test/rsadecrypt.sh
+++ b/test/rsadecrypt.sh
@@ -9,7 +9,7 @@ export PATH=${PWD}:${PATH}
 DIR=$(mktemp -d)
 echo -n "abcde12345abcde12345">${DIR}/mydata
 
-tpm2_startup -c || true
+tpm2_startup --clear || true
 
 tpm2tss-genkey -a rsa -s 2048 -p abc ${DIR}/mykey
 

--- a/test/rsasign.sh
+++ b/test/rsasign.sh
@@ -9,7 +9,7 @@ export PATH=${PWD}:${PATH}
 DIR=$(mktemp -d)
 echo -n "abcde12345abcde12345">${DIR}/mydata
 
-tpm2_startup -c || true
+tpm2_startup --clear || true
 
 tpm2tss-genkey -a rsa -s 2048 -p abc ${DIR}/mykey
 

--- a/test/rsasign_parent.sh
+++ b/test/rsasign_parent.sh
@@ -13,14 +13,15 @@ echo -n "abcde12345abcde12345">${DIR}/mydata.txt
 echo "Generating primary key"
 PARENT_CTX=${DIR}/primary_owner_key.ctx
 
-tpm2_startup -c || true
+tpm2_startup --clear || true
 
-tpm2_createprimary -a o -g sha256 -G rsa -o ${PARENT_CTX}
-tpm2_flushcontext -t
+tpm2_createprimary --hierarchy=o --halg=sha256 --kalg=rsa \
+                   --out-context-name=${PARENT_CTX}
+tpm2_flushcontext --transient-object
 
 # Load primary key to persistent handle
-HANDLE=$(tpm2_evictcontrol -a o -c ${PARENT_CTX} | cut -d ' ' -f 2)
-tpm2_flushcontext -t
+HANDLE=$(tpm2_evictcontrol --hierarchy=o --context=${PARENT_CTX} | cut -d ' ' -f 2)
+tpm2_flushcontext --transient-object
 
 # Generating a key underneath the persistent parent
 tpm2tss-genkey -a rsa -s 2048 -p abc -P ${HANDLE} ${DIR}/mykey
@@ -31,7 +32,7 @@ cat ${DIR}/mykey.pub
 echo "abc" | openssl pkeyutl -engine tpm2tss -keyform engine -inkey ${DIR}/mykey -sign -in ${DIR}/mydata.txt -out ${DIR}/mysig -passin stdin
 
 # Release persistent HANDLE
-tpm2_evictcontrol -a o -c ${HANDLE} -p ${HANDLE}
+tpm2_evictcontrol --hierarchy=o --context=${HANDLE} --persistent=${HANDLE}
 
 cat ${DIR}/mysig
 

--- a/test/rsasign_persistent.sh
+++ b/test/rsasign_persistent.sh
@@ -13,33 +13,40 @@ echo -n "abcde12345abcde12345">${DIR}/mydata.txt
 echo "Generating primary key"
 PARENT_CTX=${DIR}/primary_owner_key.ctx
 
-tpm2_startup -c || true
+tpm2_startup --clear || true
 
-tpm2_createprimary -a o -g sha256 -G rsa -o ${PARENT_CTX}
-tpm2_flushcontext -t
+tpm2_createprimary --hierarchy=o --halg=sha256 --kalg=rsa \
+                   --out-context-name=${PARENT_CTX}
+tpm2_flushcontext --transient-object
 
 # Create an RSA key pair
 echo "Generating RSA key pair"
 TPM_RSA_PUBKEY=${DIR}/rsakey.pub
 TPM_RSA_KEY=${DIR}/rsakey
-tpm2_create -p abc -C ${PARENT_CTX} -g sha256 -G rsa -u ${TPM_RSA_PUBKEY} -r ${TPM_RSA_KEY} -b sign\|decrypt\|fixedtpm\|fixedparent\|sensitivedataorigin\|userwithauth\|noda
-tpm2_flushcontext -t
+tpm2_create --auth-key=abc \
+            --context-parent=${PARENT_CTX} \
+            --halg=sha256 --kalg=rsa \
+            --pubfile=${TPM_RSA_PUBKEY} --privfile=${TPM_RSA_KEY} \
+            --object-attributes=sign\|decrypt\|fixedtpm\|fixedparent\|sensitivedataorigin\|userwithauth\|noda
+tpm2_flushcontext --transient-object
 
 # Load Key to persistent handle
 RSA_CTX=${DIR}/rsakey.ctx
-tpm2_load -C ${PARENT_CTX} -u ${TPM_RSA_PUBKEY} -r ${TPM_RSA_KEY} -o ${RSA_CTX}
-tpm2_flushcontext -t
+tpm2_load --context-parent=${PARENT_CTX} \
+          --pubfile=${TPM_RSA_PUBKEY} --privfile=${TPM_RSA_KEY} \
+          --out-context=${RSA_CTX}
+tpm2_flushcontext --transient-object
 
-HANDLE=$(tpm2_evictcontrol -a o -c ${RSA_CTX} | cut -d ' ' -f 2)
-tpm2_flushcontext -t
+HANDLE=$(tpm2_evictcontrol --hierarchy=o --context=${RSA_CTX} | cut -d ' ' -f 2)
+tpm2_flushcontext --transient-object
 
 # Signing Data
 echo "abc" | openssl pkeyutl -engine tpm2tss -keyform engine -inkey ${HANDLE} -sign -in ${DIR}/mydata.txt -out ${DIR}/mysig -passin stdin
 # Get public key of handle
-tpm2_readpublic -c ${HANDLE} -o ${DIR}/mykey.pem -f pem
+tpm2_readpublic --context=${HANDLE} --out-file=${DIR}/mykey.pem --format=pem
 
 # Release persistent HANDLE
-tpm2_evictcontrol -a o -c ${HANDLE}
+tpm2_evictcontrol --hierarchy=o --context=${HANDLE} --persistent=${HANDLE}
 
 R="$(openssl pkeyutl -pubin -inkey ${DIR}/mykey.pem -verify -in ${DIR}/mydata.txt -sigfile ${DIR}/mysig || true)"
 if ! echo $R | grep "Signature Verified Successfully" >/dev/null; then

--- a/test/rsasign_persistent.sh
+++ b/test/rsasign_persistent.sh
@@ -22,7 +22,7 @@ tpm2_flushcontext -t
 echo "Generating RSA key pair"
 TPM_RSA_PUBKEY=${DIR}/rsakey.pub
 TPM_RSA_KEY=${DIR}/rsakey
-tpm2_create -p abc -C ${PARENT_CTX} -g sha256 -G rsa -u ${TPM_RSA_PUBKEY} -r ${TPM_RSA_KEY} -A sign\|decrypt\|fixedtpm\|fixedparent\|sensitivedataorigin\|userwithauth\|noda
+tpm2_create -p abc -C ${PARENT_CTX} -g sha256 -G rsa -u ${TPM_RSA_PUBKEY} -r ${TPM_RSA_KEY} -b sign\|decrypt\|fixedtpm\|fixedparent\|sensitivedataorigin\|userwithauth\|noda
 tpm2_flushcontext -t
 
 # Load Key to persistent handle

--- a/test/rsasign_persistent_emptyauth.sh
+++ b/test/rsasign_persistent_emptyauth.sh
@@ -13,25 +13,31 @@ echo -n "abcde12345abcde12345">${DIR}/mydata.txt
 echo "Generating primary key"
 PARENT_CTX=${DIR}/primary_owner_key.ctx
 
-tpm2_startup -c || true
+tpm2_startup --clear || true
 
-tpm2_createprimary -a o -g sha256 -G rsa -o ${PARENT_CTX}
-tpm2_flushcontext -t
+tpm2_createprimary --hierarchy=o --halg=sha256 --kalg=rsa \
+                   --out-context-name=${PARENT_CTX}
+tpm2_flushcontext --transient-object
 
 # Create an RSA key pair
 echo "Generating RSA key pair"
 TPM_RSA_PUBKEY=${DIR}/rsakey.pub
 TPM_RSA_KEY=${DIR}/rsakey
-tpm2_create -C ${PARENT_CTX} -g sha256 -G rsa -u ${TPM_RSA_PUBKEY} -r ${TPM_RSA_KEY} -b sign\|decrypt\|fixedtpm\|fixedparent\|sensitivedataorigin\|userwithauth\|noda
-tpm2_flushcontext -t
+tpm2_create --context-parent=${PARENT_CTX} \
+            --halg=sha256 --kalg=rsa \
+            --pubfile=${TPM_RSA_PUBKEY} --privfile=${TPM_RSA_KEY} \
+            --object-attributes=sign\|decrypt\|fixedtpm\|fixedparent\|sensitivedataorigin\|userwithauth\|noda
+tpm2_flushcontext --transient-object
 
 # Load Key to persistent handle
 RSA_CTX=${DIR}/rsakey.ctx
-tpm2_load -C ${PARENT_CTX} -u ${TPM_RSA_PUBKEY} -r ${TPM_RSA_KEY} -o ${RSA_CTX}
-tpm2_flushcontext -t
+tpm2_load --context-parent=${PARENT_CTX} \
+          --pubfile=${TPM_RSA_PUBKEY} --privfile=${TPM_RSA_KEY} \
+          --out-context=${RSA_CTX}
+tpm2_flushcontext --transient-object
 
-HANDLE=$(tpm2_evictcontrol -a o -c ${RSA_CTX} | cut -d ' ' -f 2)
-tpm2_flushcontext -t
+HANDLE=$(tpm2_evictcontrol --hierarchy=o --context=${RSA_CTX} | cut -d ' ' -f 2)
+tpm2_flushcontext --transient-object
 
 # Signing Data
 #Actually signing should not require an auth value
@@ -46,10 +52,10 @@ EOF
 fi
 
 # Get public key of handle
-tpm2_readpublic -c ${HANDLE} -o ${DIR}/mykey.pem -f pem
+tpm2_readpublic --context=${HANDLE} --out-file=${DIR}/mykey.pem --format=pem
 
 # Release persistent HANDLE
-tpm2_evictcontrol -a o -c ${HANDLE} -p ${HANDLE}
+tpm2_evictcontrol --hierarchy=o --context=${HANDLE} --persistent=${HANDLE}
 
 R="$(openssl pkeyutl -pubin -inkey ${DIR}/mykey.pem -verify -in ${DIR}/mydata.txt -sigfile ${DIR}/mysig || true)"
 if ! echo $R | grep "Signature Verified Successfully" >/dev/null; then

--- a/test/rsasign_persistent_emptyauth.sh
+++ b/test/rsasign_persistent_emptyauth.sh
@@ -22,7 +22,7 @@ tpm2_flushcontext -t
 echo "Generating RSA key pair"
 TPM_RSA_PUBKEY=${DIR}/rsakey.pub
 TPM_RSA_KEY=${DIR}/rsakey
-tpm2_create -C ${PARENT_CTX} -g sha256 -G rsa -u ${TPM_RSA_PUBKEY} -r ${TPM_RSA_KEY} -A sign\|decrypt\|fixedtpm\|fixedparent\|sensitivedataorigin\|userwithauth\|noda
+tpm2_create -C ${PARENT_CTX} -g sha256 -G rsa -u ${TPM_RSA_PUBKEY} -r ${TPM_RSA_KEY} -b sign\|decrypt\|fixedtpm\|fixedparent\|sensitivedataorigin\|userwithauth\|noda
 tpm2_flushcontext -t
 
 # Load Key to persistent handle


### PR DESCRIPTION
- First make them work again.
- Use the long-form parameters.
- Document their use in the INSTALL.md file.