### PR TITLE
build: link against tss2-mu

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -33,9 +33,9 @@
 INCLUDE_DIRS    = -I$(srcdir)/include -I$(srcdir)/src
 ACLOCAL_AMFLAGS = -I m4 --install
 AM_CFLAGS       = $(INCLUDE_DIRS) $(EXTRA_CFLAGS) $(TSS2_ESYS_CFLAGS) \
-                  $(CRYPTO_CFLAGS) $(CODE_COVERAGE_CFLAGS)
+                  $(TSS2_MU_CFLAGS) $(CRYPTO_CFLAGS) $(CODE_COVERAGE_CFLAGS)
 AM_LDFLAGS      = $(EXTRA_LDFLAGS) $(CODE_COVERAGE_LIBS)
-AM_LDADD        = $(TSS2_ESYS_LIBS) $(CRYPTO_LIBS) -ldl
+AM_LDADD        = $(TSS2_ESYS_LIBS) $(TSS2_MU_LIBS) $(CRYPTO_LIBS) -ldl
 
 AM_DISTCHECK_CONFIGURE_FLAGS = --with-enginesdir= --with-completionsdir= \
                                --enable-unit

--- a/configure.ac
+++ b/configure.ac
@@ -108,6 +108,7 @@ PKG_PROG_PKG_CONFIG([0.25])
 PKG_CHECK_MODULES([CRYPTO], [libcrypto >= 1.0.2g],
                   [ac_enginesdir=`$PKG_CONFIG --variable=enginesdir libcrypto`])
 PKG_CHECK_MODULES([TSS2_ESYS], [tss2-esys >= 2.2.2])
+PKG_CHECK_MODULES([TSS2_MU], [tss2-mu])
 
 AC_PATH_PROG([PANDOC], [pandoc])
 AS_IF([test -z "$PANDOC"],


### PR DESCRIPTION
Currently the linking of `libtpm2tss` relies on the fact that the upstream tpm2-tss pkg-config file explicitly requires tss2-mu. Since this is wrong and will be changed upstream, but we need access to the marshalling functions, explicitly link against tss2-mu. See https://github.com/tpm2-software/tpm2-tss/pull/1417 for a more detailed discussion.