### PR TITLE
 test: use tpm2-tools 3.X

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,9 +7,9 @@ dist: xenial
 
 env:
   matrix:
-  - OPENSSL_BRANCH=OpenSSL_1_0_2-stable TPM2TSS_BRANCH=2.2.x
-  - OPENSSL_BRANCH=OpenSSL_1_1_0-stable TPM2TSS_BRANCH=2.2.x
-  - OPENSSL_BRANCH=OpenSSL_1_1_1-stable TPM2TSS_BRANCH=2.2.x
+  - OPENSSL_BRANCH=OpenSSL_1_0_2-stable TPM2TSS_BRANCH=2.2.x TPM2TOOLS_BRANCH=3.X
+  - OPENSSL_BRANCH=OpenSSL_1_1_0-stable TPM2TSS_BRANCH=2.2.x TPM2TOOLS_BRANCH=3.X
+  - OPENSSL_BRANCH=OpenSSL_1_1_1-stable TPM2TSS_BRANCH=2.2.x TPM2TOOLS_BRANCH=3.X
   global:
   - TPM2TOOLS_TCTI=mssim
   - PATH="${PWD}/installdir/usr/local/bin:${PATH}"
@@ -76,10 +76,10 @@ install:
   - rm ${PWD}/../installdir/usr/local/lib/*.la
   - popd
 # tpm2-tools
-  - git clone --depth=1 https://github.com/tpm2-software/tpm2-tools.git
+  - git clone --depth=1 -b ${TPM2TOOLS_BRANCH} https://github.com/tpm2-software/tpm2-tools.git
   - pushd tpm2-tools
   - mkdir m4 || true
-  - cp ../autoconf-archive-2017.09.28/m4/ax_code_coverage.m4 ../autoconf-archive-2017.09.28/m4/ax_is_release.m4 m4/
+  - cp ../autoconf-archive-2017.09.28/m4/ax_code_coverage.m4 m4/
   - ./bootstrap
   # Some workarounds for tpm2-tools with -Wno-XXX
   - ./configure --disable-hardening CFLAGS="-I${PWD}/../installdir/usr/local/include -Wno-unused-value -Wno-missing-field-initializer" LDFLAGS=-L${PWD}/../installdir/usr/local/lib

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -14,7 +14,7 @@
 
 Integration tests also require:
 * expect
-* tpm2-tools >=4.0 (or master)
+* tpm2-tools 3.2 (or 3.X branch)
 * tpm_server
 * realpath
 * ss

--- a/test/rsasign_persistent.sh
+++ b/test/rsasign_persistent.sh
@@ -9,14 +9,14 @@ echo "Generating primary key"
 PARENT_CTX=primary_owner_key.ctx
 
 tpm2_createprimary --hierarchy=o --halg=sha256 --kalg=rsa \
-                   --out-context-name=${PARENT_CTX}
+                   --context=${PARENT_CTX}
 tpm2_flushcontext --transient-object
 
 # Create an RSA key pair
 echo "Generating RSA key pair"
 TPM_RSA_PUBKEY=rsakey.pub
 TPM_RSA_KEY=rsakey
-tpm2_create --auth-key=abc \
+tpm2_create --pwdk=abc \
             --context-parent=${PARENT_CTX} \
             --halg=sha256 --kalg=rsa \
             --pubfile=${TPM_RSA_PUBKEY} --privfile=${TPM_RSA_KEY} \
@@ -27,19 +27,19 @@ tpm2_flushcontext --transient-object
 RSA_CTX=rsakey.ctx
 tpm2_load --context-parent=${PARENT_CTX} \
           --pubfile=${TPM_RSA_PUBKEY} --privfile=${TPM_RSA_KEY} \
-          --out-context=${RSA_CTX}
+          --context=${RSA_CTX}
 tpm2_flushcontext --transient-object
 
-HANDLE=$(tpm2_evictcontrol --hierarchy=o --context=${RSA_CTX} | cut -d ' ' -f 2 | head -n 1)
+HANDLE=$(tpm2_evictcontrol --auth=o --context=${RSA_CTX} --persistent=0x81010001 | cut -d ' ' -f 2 | head -n 1)
 tpm2_flushcontext --transient-object
 
 # Signing Data
 echo "abc" | openssl pkeyutl -engine tpm2tss -keyform engine -inkey ${HANDLE} -sign -in mydata.txt -out mysig -passin stdin
 # Get public key of handle
-tpm2_readpublic --context=${HANDLE} --out-file=mykey.pem --format=pem
+tpm2_readpublic --object=${HANDLE} --opu=mykey.pem --format=pem
 
 # Release persistent HANDLE
-tpm2_evictcontrol --hierarchy=o --context=${HANDLE} --persistent=${HANDLE}
+tpm2_evictcontrol --auth=o --handle=${HANDLE} --persistent=${HANDLE}
 
 R="$(openssl pkeyutl -pubin -inkey mykey.pem -verify -in mydata.txt -sigfile mysig || true)"
 if ! echo $R | grep "Signature Verified Successfully" >/dev/null; then

--- a/test/rsasign_persistent_emptyauth.sh
+++ b/test/rsasign_persistent_emptyauth.sh
@@ -9,7 +9,7 @@ echo "Generating primary key"
 PARENT_CTX=primary_owner_key.ctx
 
 tpm2_createprimary --hierarchy=o --halg=sha256 --kalg=rsa \
-                   --out-context-name=${PARENT_CTX}
+                   --context=${PARENT_CTX}
 tpm2_flushcontext --transient-object
 
 # Create an RSA key pair
@@ -26,10 +26,10 @@ tpm2_flushcontext --transient-object
 RSA_CTX=rsakey.ctx
 tpm2_load --context-parent=${PARENT_CTX} \
           --pubfile=${TPM_RSA_PUBKEY} --privfile=${TPM_RSA_KEY} \
-          --out-context=${RSA_CTX}
+          --context=${RSA_CTX}
 tpm2_flushcontext --transient-object
 
-HANDLE=$(tpm2_evictcontrol --hierarchy=o --context=${RSA_CTX} | cut -d ' ' -f 2 | head -n 1)
+HANDLE=$(tpm2_evictcontrol --auth=o --context=${RSA_CTX} --persistent=0x81010001 | cut -d ' ' -f 2 | head -n 1)
 tpm2_flushcontext --transient-object
 
 # Signing Data
@@ -45,10 +45,10 @@ EOF
 fi
 
 # Get public key of handle
-tpm2_readpublic --context=${HANDLE} --out-file=mykey.pem --format=pem
+tpm2_readpublic --object=${HANDLE} --opu=mykey.pem --format=pem
 
 # Release persistent HANDLE
-tpm2_evictcontrol --hierarchy=o --context=${HANDLE} --persistent=${HANDLE}
+tpm2_evictcontrol --auth=o --handle=${HANDLE} --persistent=${HANDLE}
 
 R="$(openssl pkeyutl -pubin -inkey mykey.pem -verify -in mydata.txt -sigfile mysig || true)"
 if ! echo $R | grep "Signature Verified Successfully" >/dev/null; then


### PR DESCRIPTION
Since https://github.com/tpm2-software/tpm2-tools/commit/893e43271024e9c2d942c8dc9ba1657a667bb0e2 tpm2-tools explicitly requires tpm2-tss >=2.3.0, so we switch to the stable version of tpm2-tools instead. This has been attempted previously in #61, but failed due to the missing `tpm2_flushcontext` tool. Since that tool has been [backported to tpm2-tools 3.X](https://github.com/tpm2-software/tpm2-tools/pull/1471), we can now use it for the CI. Therefore this is basically a rewrite of #61 for the long option names introduced in https://github.com/tpm2-software/tpm2-tss-engine/pull/110.

Note that tpm2-tools 3.2 that will [include tpm2_flushcontext](https://lists.01.org/pipermail/tpm2/2019-May/001195.html) is not yet released, so users can't run the integration tests with the tpm2-tools package provided by their distribution. Until that happens, they will manually have to build the [tpm2-tools 3.X branch](https://github.com/tpm2-software/tpm2-tools/tree/3.X) instead.