### PR TITLE
added NO_DL build configuration

### DIFF
--- a/src/tpm2-tss-engine-tcti.c
+++ b/src/tpm2-tss-engine-tcti.c
@@ -73,7 +73,7 @@ tcti_expand_dlname(const char *shortname)
 static TSS2_RC
 tcti_dlopen(const char *dl_path, dl_handle_t *dlhandle_p)
 {
-    TSS2_RC r = TSS2_RC_SUCCESS;
+    TSS2_RC r;
     dl_handle_t dlhandle = dlopen(dl_path, RTLD_LAZY);
     if (dlhandle) {
         *dlhandle_p = dlhandle;

--- a/src/tpm2-tss-engine-tcti.c
+++ b/src/tpm2-tss-engine-tcti.c
@@ -208,11 +208,10 @@ tcti_set_opts(const char *opts)
        case D: path:\0      --> path=path\0,    cfg=\0
        case E: path:cfg\0   --> path=path\0,    cfg=cfg\0
 
-       Following opts are invalid if NO_DL is not defined (cfg without path.
-       must be explicitly handled, because dlopen("") returns handle of main
-       program):
+       Following opts are invalid (cfg without path. must be explicitly
+       handled, because dlopen("") returns handle of main program):
        case F: :\0          --> path=\0,        cfg=\0
-       case G: :cfg\0       --> path=\0,        cfg=cfg\0
+       case G: :cfg\0       --> path=\0,        cfg=\0
      */
     TSS2_RC r;
     char *path, *cfg;
@@ -236,16 +235,10 @@ tcti_set_opts(const char *opts)
             } else {
                 if (split == path) {
                     /* case F and case G */
-#ifndef NO_DL
                     ERR(tcti_set_opts, TPM2TSS_R_GENERAL_FAILURE);
                     /* Invalid opts: free the buffer */
                     OPENSSL_free(path);
                     r = TSS2_BASE_RC_BAD_REFERENCE;
-#else
-                    split[0] = '\0';
-                    cfg = split + 1;
-                    r = TSS2_RC_SUCCESS;
-#endif
                 } else {
                     /* case D and case E */
                     split[0] = '\0';


### PR DESCRIPTION
added NO_DL build configuration. If defined NO_DL, the engine will not support using the tcti shared library. Some system such as VxWorks builds the tcti as static library and links with OS image together. In this situation, shared library is not supported and should be removed from engine.