### PR TITLE
This patch adds engine load routine for OpenSSL.

### DIFF
--- a/include/tpm2-tss-engine.h
+++ b/include/tpm2-tss-engine.h
@@ -1,6 +1,8 @@
 /*******************************************************************************
  * Copyright 2017-2018, Fraunhofer SIT sponsored by Infineon Technologies AG
  * All rights reserved.
+ * Copyright (c) 2019, Wind River Systems.
+ * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:
@@ -82,5 +84,10 @@ tpm2tss_ecc_getappdata(EC_KEY *key);
 
 int
 tpm2tss_ecc_setappdata(EC_KEY *key, TPM2_DATA *data);
+
+#ifdef OPENSSL_NO_DYNAMIC_ENGINE
+void
+ENGINE_load_tpm2tss(void);
+#endif /* OPENSSL_NO_DYNAMIC_ENGINE */
 
 #endif /* TPM2_TSS_ENGINE_H */

--- a/src/tpm2-tss-engine.c
+++ b/src/tpm2-tss-engine.c
@@ -1,6 +1,8 @@
 /*******************************************************************************
  * Copyright 2017-2018, Fraunhofer SIT sponsored by Infineon Technologies AG
  * All rights reserved.
+ * Copyright (c) 2019, Wind River Systems.
+ * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:
@@ -224,6 +226,7 @@ loadkey(ENGINE *e, const char *key_id, UI_METHOD *ui, void *cb_data)
         goto error;
     }
 
+    pkey->engine = e;
     DBG("TPM2 Key loaded\n");
 
     return pkey;
@@ -356,5 +359,22 @@ bind(ENGINE *e, const char *id)
     return 0;
 }
 
+#ifdef OPENSSL_NO_DYNAMIC_ENGINE
+void ENGINE_load_tpm2tss(void)
+{
+    ENGINE *eng = ENGINE_new();
+    if (!eng)
+        return;
+    if (!bind(eng, NULL)) {
+        ENGINE_free(eng);
+        return;
+    }
+
+    ENGINE_add(eng);
+    ENGINE_free(eng);
+    ERR_clear_error();
+}
+#else
 IMPLEMENT_DYNAMIC_BIND_FN(bind)
 IMPLEMENT_DYNAMIC_CHECK_FN()
+#endif /* OPENSSL_NO_DYNAMIC_ENGINE */

--- a/src/tpm2tss-genkey.c
+++ b/src/tpm2tss-genkey.c
@@ -1,6 +1,8 @@
 /*******************************************************************************
  * Copyright 2017-2018, Fraunhofer SIT sponsored by Infineon Technologies AG
  * All rights reserved.
+ * Copyright (c) 2019, Wind River Systems.
+ * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:
@@ -297,7 +299,11 @@ main(int argc, char **argv)
     TPM2_DATA *tpm2Data = NULL;
 
     /* Initialize the tpm2-tss engine */
+#ifdef OPENSSL_NO_DYNAMIC_ENGINE
+    ENGINE_load_tpm2tss();
+#else
     ENGINE_load_dynamic();
+#endif /* OPENSSL_NO_DYNAMIC_ENGINE */
 
     /* Openssl 1.1.0 requires the lib-prefix for the engine_id */
     ENGINE *tpm_engine = ENGINE_by_id("tpm2tss");


### PR DESCRIPTION
If OpenSSL doesn't support load the engines dynamicly,
we need to provide a special load routine so that the applications could call this routine for loading the engine by themself.