### PR TITLE
Fix EC param info: from explicit to named curve format.

### DIFF
--- a/src/tpm2-tss-engine-ecc.c
+++ b/src/tpm2-tss-engine-ecc.c
@@ -278,6 +278,7 @@ populate_ecc(EC_KEY *key)
         EC_GROUP_free(ecgroup);
         return 0;
     }
+    EC_KEY_set_asn1_flag(key, OPENSSL_EC_NAMED_CURVE);
     EC_GROUP_free(ecgroup);
 
     x = BN_bin2bn(tpm2Data->pub.publicArea.unique.ecc.x.buffer,


### PR DESCRIPTION
This change is regarding the fix for this issue: https://github.com/tpm2-software/tpm2-tss-engine/issues/124.
This change allows encoding of EC public key information in the form of named curve format rather than explicit curve parameter format while using through OpenSSL command.