### PR TITLE
Revert "Add ccache to speed up travis runs."

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,8 +5,6 @@ compiler:
 
 dist: xenial
 
-cache: ccache
-
 env:
   matrix:
   - OPENSSL_BRANCH=OpenSSL_1_0_2-stable TPM2TSS_BRANCH=2.2.x TPM2TOOLS_BRANCH=3.X


### PR DESCRIPTION
This reverts commit 2ee71ee4848b0e58ad141fc48c121f66961631eb.

Since travis ccache caching and OpenSSL 1.0.2 lead to corrupted builds, we revert this.