### PR TITLE
ci: set final OpenSSL installation directory during ./config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -39,14 +39,9 @@ install:
 # OpenSSL 1.0.2 / 1.1.0
   - git clone --branch $OPENSSL_BRANCH --depth=1 https://github.com/openssl/openssl.git
   - pushd openssl
-  - ./config --prefix=/usr/local --openssldir=/usr/local/openssl shared
+  - ./config --prefix=${PWD}/../installdir/usr/local --openssldir=${PWD}/../installdir/usr/local/openssl shared
   - make -j$(nproc)
-  - |
-    if [ "$OPENSSL_BRANCH" == "OpenSSL_1_0_2-stable" ]; then
-        make install INSTALL_PREFIX=${PWD}/../installdir
-    else
-        make install DESTDIR=${PWD}/../installdir
-    fi
+  - make install
   - which openssl
   - popd
 # TPM Simulator

--- a/test/sclient.sh
+++ b/test/sclient.sh
@@ -2,9 +2,6 @@
 
 set -eufx
 
-#The following is for DESTDIR-installations of openssl
-export OPENSSL_CONF=$(find $(dirname $(which openssl))/../../ -name openssl.cnf | head -n 1)
-
 if openssl version | grep "OpenSSL 1.0.2" >/dev/null; then
     echo "OpenSSL 1.0.2 does not load the certificate; private key mismatch ???"
     exit 77

--- a/test/sserver.sh
+++ b/test/sserver.sh
@@ -2,9 +2,6 @@
 
 set -eufx
 
-#The following is for DESTDIR-installations of openssl
-export OPENSSL_CONF=$(find $(dirname $(which openssl))/../../ -name openssl.cnf | head -n 1)
-
 if openssl version | grep "OpenSSL 1.0.2" >/dev/null; then
     echo "OpenSSL 1.0.2 does not load the certificate; private key mismatch ???"
     exit 77


### PR DESCRIPTION
Currently OpenSSL is installed to a different directory than the one specified in `./config` by using `make install DESTDIR=...`. This leads to OpenSSL looking for its configuration file in the wrong folder. Specifying the final installation directory during configuration allows to remove the [somewhat brittle](https://github.com/tpm2-software/tpm2-tss-engine/issues/132) `OPENSSL_CONF` specification in the tests.