### PR TITLE
Add support for using a parent key password

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -117,6 +117,7 @@ TESTS_SHELL = test/ecdsa.sh \
               test/failload.sh \
               test/failwrite.sh \
               test/rsasign_parent.sh \
+              test/rsasign_parent_pass.sh \
               test/rsasign_persistent.sh \
               test/rsasign_persistent_emptyauth.sh \
               test/sserver.sh \

--- a/bash-completion/tpm2tss-genkey
+++ b/bash-completion/tpm2tss-genkey
@@ -27,9 +27,13 @@ _tpm2tss-genkey()
         COMPREPLY=( $(compgen -W "2048" -- ${cur}) );
         return 0
         ;;
+    -W | --parentpw)
+        COMPREPLY=""
+        return 0
+        ;;
     esac;
 
-    opts="-a --alg -c --curve -e --exponent -h --help -o --ownerpw -p --password -s --keysize -v --verbose"
+    opts="-a --alg -c --curve -e --exponent -h --help -o --ownerpw -p --password -s --keysize -v --verbose -W --parentpw"
     if [[ ${cur} = -* ]] ; then
         COMPREPLY=( $(compgen -W "${opts}" -- ${cur}) )
         return 0

--- a/include/tpm2-tss-engine.h
+++ b/include/tpm2-tss-engine.h
@@ -53,6 +53,7 @@ typedef struct {
 
 #define TPM2TSS_SET_OWNERAUTH   ENGINE_CMD_BASE
 #define TPM2TSS_SET_TCTI        (ENGINE_CMD_BASE + 1)
+#define TPM2TSS_SET_PARENTAUTH  (ENGINE_CMD_BASE + 2)
 
 int
 tpm2tss_tpm2data_write(const TPM2_DATA *tpm2data, const char *filename);

--- a/man/tpm2tss-genkey.1.md
+++ b/man/tpm2tss-genkey.1.md
@@ -47,6 +47,9 @@ key information. This file can then be loaded with OpenSSL using
   * `-v`, `--verbose`:
     Print verbose messages
 
+  * `-W <password>`, `--parentpw <password>`:
+    Password for the parent key (default: none)
+
 # EXAMPLES
 
 Engine informations can be retrieved using:

--- a/src/tpm2-tss-engine-common.c
+++ b/src/tpm2-tss-engine-common.c
@@ -462,6 +462,9 @@ init_tpm_parent(ESYS_AUXCONTEXT *eactx_p,
                                   parent);
         ERRchktss(init_tpm_parent, r, goto error);
 
+        r = Esys_TR_SetAuth(eactx_p->ectx, *parent, &parentauth);
+        ERRchktss(init_tpm_parent, r, goto error);
+
         return TSS2_RC_SUCCESS;
     }
 

--- a/src/tpm2-tss-engine-common.h
+++ b/src/tpm2-tss-engine-common.h
@@ -44,6 +44,7 @@
 #include <openssl/pem.h>
 
 extern TPM2B_DIGEST ownerauth;
+extern TPM2B_DIGEST parentauth;
 
 int init_ecc(ENGINE *e);
 int init_rand(ENGINE *e);

--- a/src/tpm2-tss-engine.c
+++ b/src/tpm2-tss-engine.c
@@ -54,6 +54,7 @@ static const char *engine_id = "tpm2tss";
 static const char *engine_name = "TPM2-TSS engine for OpenSSL";
 
 TPM2B_DIGEST ownerauth = { .size = 0 };
+TPM2B_DIGEST parentauth = { .size = 0 };
 
 /** Retrieve password
  *
@@ -120,6 +121,9 @@ static const ENGINE_CMD_DEFN cmd_defns[] = {
     { TPM2TSS_SET_TCTI, "SET_TCTI",
      "Set the TCTI module and options (default none)",
      ENGINE_CMD_FLAG_STRING },
+    { TPM2TSS_SET_PARENTAUTH, "SET_PARENTAUTH",
+     "Set the password for the parent key (default none)",
+     ENGINE_CMD_FLAG_STRING },
     {0, NULL, NULL, 0}
 };
 
@@ -158,6 +162,19 @@ engine_ctrl(ENGINE *e, int cmd, long i, void *p, void (*f) ())
                 return 1;
             }
         }
+    case TPM2TSS_SET_PARENTAUTH:
+        if (!p) {
+            DBG("Setting parent auth to empty auth.\n");
+            parentauth.size = 0;
+            return 1;
+        }
+        DBG("Setting parent auth to password.\n");
+        if (strlen((char *)p) > sizeof(parentauth.buffer) - 1) {
+            return 0;
+        }
+        parentauth.size = strlen((char *)p);
+        memcpy(&parentauth.buffer[0], p, parentauth.size);
+        return 1;
     default:
         break;
     }

--- a/src/tpm2tss-genkey.c
+++ b/src/tpm2tss-genkey.c
@@ -59,9 +59,10 @@ char *help =
     "    -P, --parent    specific handle for the parent key (default: none)\n"
     "    -s, --keysize   key size in bits for rsa (default: 2048)\n"
     "    -v, --verbose   print verbose messages\n"
+    "    -W, --parentpw  password for the parent key (default: none)\n"
     "\n";
 
-static const char *optstr = "a:c:e:ho:p:P:s:v";
+static const char *optstr = "a:c:e:ho:p:P:s:vW:";
 
 static const struct option long_options[] = {
     {"alg",      required_argument, 0, 'a'},
@@ -73,6 +74,7 @@ static const struct option long_options[] = {
     {"parent",   required_argument, 0, 'P'},
     {"keysize",  required_argument, 0, 's'},
     {"verbose",  no_argument,       0, 'v'},
+    {"parentpw", required_argument, 0, 'W'},
     {0,          0,                 0,  0 }
 };
 
@@ -84,6 +86,7 @@ static struct opt {
     char *ownerpw;
     char *password;
     TPM2_HANDLE parent;
+    char *parentpw;
     int keysize;
     int verbose;
 } opt;
@@ -108,6 +111,7 @@ parse_opts(int argc, char **argv)
     opt.ownerpw = NULL;
     opt.password = NULL;
     opt.parent = 0;
+    opt.parentpw = NULL;
     opt.keysize = 2048;
     opt.verbose = 0;
 
@@ -164,6 +168,9 @@ parse_opts(int argc, char **argv)
                 ERR("Error parsing parent handle");
                 exit(1);
             }
+            break;
+        case 'W':
+            opt.parentpw = optarg;
             break;
         case 's':
             if (sscanf(optarg, "%i", &opt.keysize) != 1) {
@@ -316,6 +323,11 @@ main(int argc, char **argv)
 
     if (!ENGINE_ctrl(tpm_engine, TPM2TSS_SET_OWNERAUTH, 0, opt.ownerpw, NULL)) {
         ERR("Could not set ownerauth\n");
+        return 1;
+    }
+
+    if (!ENGINE_ctrl(tpm_engine, TPM2TSS_SET_PARENTAUTH, 0, opt.parentpw, NULL)) {
+        ERR("Could not set parentauth\n");
         return 1;
     }
 

--- a/test/rsasign_parent_pass.sh
+++ b/test/rsasign_parent_pass.sh
@@ -1,0 +1,50 @@
+#!/bin/bash
+
+set -eufx
+
+echo -n "abcde12345abcde12345">mydata.txt
+
+# Create an Primary key pair
+echo "Generating primary key"
+PARENT_CTX=primary_owner_key.ctx
+
+tpm2_createprimary --hierarchy=o --halg=sha256 --kalg=rsa \
+                   --context=${PARENT_CTX} --pwdk=abc
+tpm2_flushcontext --transient-object
+
+# Load primary key to persistent handle
+HANDLE=$(tpm2_evictcontrol --auth=o --context=${PARENT_CTX} --persistent=0x81010001 | cut -d ' ' -f 2 | head -n 1)
+tpm2_flushcontext --transient-object
+
+# Generating a key underneath the persistent, password protected, parent
+tpm2tss-genkey -a rsa -s 2048 -p abc -P ${HANDLE} -W abc mykey
+
+cat > engine.conf <<EOF
+    openssl_conf = openssl_init
+
+    [openssl_init]
+    engines = engine_section
+
+    [engine_section]
+    tpm2tss = tpm2tss_section
+
+    [tpm2tss_section]
+    SET_PARENTAUTH = abc
+EOF
+
+export OPENSSL_CONF=engine.conf
+
+echo "abc" | openssl rsa -engine tpm2tss -inform engine -in mykey -pubout -outform pem -out mykey.pub -passin stdin
+cat mykey.pub
+
+echo "abc" | openssl pkeyutl -engine tpm2tss -keyform engine -inkey mykey -sign -in mydata.txt -out mysig -passin stdin
+
+# Release persistent HANDLE
+tpm2_evictcontrol --auth=o --handle=${HANDLE} --persistent=${HANDLE}
+
+#this is a workaround because -verify allways exits 1
+R="$(openssl pkeyutl -pubin -inkey mykey.pub -verify -in mydata.txt -sigfile mysig || true)"
+if ! echo $R | grep "Signature Verified Successfully" >/dev/null; then
+    echo $R
+    exit 1
+fi

--- a/test/sh_log_compiler.sh
+++ b/test/sh_log_compiler.sh
@@ -7,6 +7,9 @@ export PATH="$PWD:$PATH"
 
 test_script="$(realpath "$1")"
 
+echo "Creating tpm2tss symlink"
+ln -fs libtpm2tss.so .libs/tpm2tss.so
+
 tmp_dir="$(mktemp --directory)"
 echo "Switching to temporary directory $tmp_dir"
 cd "$tmp_dir"


### PR DESCRIPTION
This PR adds support for providing a parent key password to tpm2tss-genkey and extends the engine to support setting it using an ENGINE_ctrl() command (TPM2TSS_SET_PARENTAUTH or "SET_PARENTAUTH").