### PR TITLE
Support setting binary passwords

### DIFF
--- a/man/tpm2tss-genkey.1.md
+++ b/man/tpm2tss-genkey.1.md
@@ -50,6 +50,18 @@ key information. This file can then be loaded with OpenSSL using
   * `-W <password>`, `--parentpw <password>`:
     Password for the parent key (default: none)
 
+## Password Formatting
+
+Passwords can be provided in two forms, string and hex-string. While a string is used
+directly for authentication a hex-string is first converted into binary form, allowing the use
+of non-printable characters. To control the interpretation the following prefixes can be used:
+
+* no prefix - Default to string interpretation.
+
+* `hex:` - Specify password in hex-string format.
+
+* `str:` - Force string interpretation, i.e. if the password starts with "hex:" or "str:".
+
 # EXAMPLES
 
 Engine informations can be retrieved using:

--- a/man/tpm2tss_ecc_genkey.3.md
+++ b/man/tpm2tss_ecc_genkey.3.md
@@ -17,6 +17,18 @@
 The ECC curve is determined by `curve`. The new key will be protected by
 `password`.
 
+## Password Formatting
+
+Passwords can be provided in two forms, string and hex-string. While a string is used
+directly for authentication a hex-string is first converted into binary form, allowing the use
+of non-printable characters. To control the interpretation the following prefixes can be used:
+
+* no prefix - Default to string interpretation.
+
+* `hex:` - Specify password in hex-string format.
+
+* `str:` - Force string interpretation, i.e. if the password starts with "hex:" or "str:".
+
 # RETURN VALUE
 
 Upon successful completion **tpm2tss_ecc_genkey**() returns 1. Otherwise 0.

--- a/man/tpm2tss_rsa_genkey.3.md
+++ b/man/tpm2tss_rsa_genkey.3.md
@@ -17,6 +17,18 @@
 The keylength is determined by `bits`. The exponent is determined by `e`.
 The new key will be protected by `password`.
 
+## Password Formatting
+
+Passwords can be provided in two forms, string and hex-string. While a string is used
+directly for authentication a hex-string is first converted into binary form, allowing the use
+of non-printable characters. To control the interpretation the following prefixes can be used:
+
+* no prefix - Default to string interpretation.
+
+* `hex:` - Specify password in hex-string format.
+
+* `str:` - Force string interpretation, i.e. if the password starts with "hex:" or "str:".
+
 # RETURN VALUE
 
 Upon successful completion **tpm2tss_rsa_genkey**() returns 1. Otherwise 0.

--- a/src/tpm2-tss-engine-common.h
+++ b/src/tpm2-tss-engine-common.h
@@ -43,8 +43,10 @@
 #include <openssl/asn1.h>
 #include <openssl/pem.h>
 
-extern TPM2B_DIGEST ownerauth;
-extern TPM2B_DIGEST parentauth;
+extern TPM2B_AUTH ownerauth;
+extern TPM2B_AUTH parentauth;
+
+int init_auth(TPM2B_AUTH* a, const char* p, size_t l);
 
 int init_ecc(ENGINE *e);
 int init_rand(ENGINE *e);

--- a/src/tpm2-tss-engine-ecc.c
+++ b/src/tpm2-tss-engine-ecc.c
@@ -458,16 +458,13 @@ tpm2tss_ecc_genkey(EC_KEY *key, TPMI_ECC_CURVE curve, const char *password,
 
     if (password) {
         DBG("Setting a password for the created key.\n");
-        if (strlen(password) > sizeof(tpm2Data->userauth.buffer) - 1) {
+        if (!init_auth(&tpm2Data->userauth, password, 0)) {
             goto error;
         }
-        tpm2Data->userauth.size = strlen(password);
-        memcpy(&tpm2Data->userauth.buffer[0], password,
-               tpm2Data->userauth.size);
 
-        inSensitive.sensitive.userAuth.size = strlen(password);
-        memcpy(&inSensitive.sensitive.userAuth.buffer[0], password,
-               strlen(password));
+        inSensitive.sensitive.userAuth.size = tpm2Data->userauth.size;
+        memcpy(&inSensitive.sensitive.userAuth.buffer[0],
+               &tpm2Data->userauth.buffer[0], tpm2Data->userauth.size);
     } else
         tpm2Data->emptyAuth = 1;
 

--- a/src/tpm2-tss-engine-rsa.c
+++ b/src/tpm2-tss-engine-rsa.c
@@ -515,16 +515,13 @@ tpm2tss_rsa_genkey(RSA *rsa, int bits, BIGNUM *e, char *password,
 
     if (password) {
         DBG("Setting a password for the created key.\n");
-        if (strlen(password) > sizeof(tpm2Data->userauth.buffer) - 1) {
+        if (!init_auth(&tpm2Data->userauth, password, 0)) {
             goto error;
         }
-        tpm2Data->userauth.size = strlen(password);
-        memcpy(&tpm2Data->userauth.buffer[0], password,
-               tpm2Data->userauth.size);
 
-        inSensitive.sensitive.userAuth.size = strlen(password);
-        memcpy(&inSensitive.sensitive.userAuth.buffer[0], password,
-               strlen(password));
+        inSensitive.sensitive.userAuth.size = tpm2Data->userauth.size;
+        memcpy(&inSensitive.sensitive.userAuth.buffer[0],
+               &tpm2Data->userauth.buffer[0], tpm2Data->userauth.size);
     } else
         tpm2Data->emptyAuth = 1;
 

--- a/test/rsasign_hexpass.sh
+++ b/test/rsasign_hexpass.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+
+set -eufx
+
+echo -n "abcde12345abcde12345">mydata
+
+tpm2tss-genkey -a rsa -s 2048 -p hex:DEADBEEF mykey
+
+echo hex:DEADBEEF | openssl rsa -engine tpm2tss -inform engine -in mykey -pubout -outform pem -out mykey.pub -passin stdin
+
+echo hex:DEADBEEF | openssl pkeyutl -engine tpm2tss -keyform engine -inkey mykey -sign -in mydata -out mysig -passin stdin
+
+#this is a workaround because -verify allways exits 1
+R="$(openssl pkeyutl -pubin -inkey mykey.pub -verify -in mydata -sigfile mysig || true)"
+if ! echo $R | grep "Signature Verified Successfully" >/dev/null; then
+    echo $R
+    exit 1
+fi

--- a/test/rsasign_parent_hexpass.sh
+++ b/test/rsasign_parent_hexpass.sh
@@ -9,7 +9,7 @@ echo "Generating primary key"
 PARENT_CTX=primary_owner_key.ctx
 
 tpm2_createprimary --hierarchy=o --halg=sha256 --kalg=rsa \
-                   --context=${PARENT_CTX} --pwdk=abc
+                   --context=${PARENT_CTX} --pwdk=hex:CAFEBABE
 tpm2_flushcontext --transient-object
 
 # Load primary key to persistent handle
@@ -17,7 +17,7 @@ HANDLE=$(tpm2_evictcontrol --auth=o --context=${PARENT_CTX} --persistent=0x81010
 tpm2_flushcontext --transient-object
 
 # Generating a key underneath the persistent, password protected, parent
-tpm2tss-genkey -a rsa -s 2048 -p def -P ${HANDLE} -W abc mykey
+tpm2tss-genkey -a rsa -s 2048 -p hex:DEADBEEF -P ${HANDLE} -W hex:CAFEBABE mykey
 
 cat > engine.conf <<EOF
     openssl_conf = openssl_init
@@ -29,15 +29,15 @@ cat > engine.conf <<EOF
     tpm2tss = tpm2tss_section
 
     [tpm2tss_section]
-    SET_PARENTAUTH = abc
+    SET_PARENTAUTH = hex:CAFEBABE
 EOF
 
 export OPENSSL_CONF=engine.conf
 
-echo def | openssl rsa -engine tpm2tss -inform engine -in mykey -pubout -outform pem -out mykey.pub -passin stdin
+echo hex:DEADBEEF | openssl rsa -engine tpm2tss -inform engine -in mykey -pubout -outform pem -out mykey.pub -passin stdin
 cat mykey.pub
 
-echo def | openssl pkeyutl -engine tpm2tss -keyform engine -inkey mykey -sign -in mydata.txt -out mysig -passin stdin
+echo hex:DEADBEEF | openssl pkeyutl -engine tpm2tss -keyform engine -inkey mykey -sign -in mydata.txt -out mysig -passin stdin
 
 # Release persistent HANDLE
 tpm2_evictcontrol --auth=o --handle=${HANDLE} --persistent=${HANDLE}

--- a/test/rsasign_parent_strhexpass.sh
+++ b/test/rsasign_parent_strhexpass.sh
@@ -9,7 +9,7 @@ echo "Generating primary key"
 PARENT_CTX=primary_owner_key.ctx
 
 tpm2_createprimary --hierarchy=o --halg=sha256 --kalg=rsa \
-                   --context=${PARENT_CTX} --pwdk=abc
+                   --context=${PARENT_CTX} --pwdk=str:hex:CAFEBABE
 tpm2_flushcontext --transient-object
 
 # Load primary key to persistent handle
@@ -17,7 +17,7 @@ HANDLE=$(tpm2_evictcontrol --auth=o --context=${PARENT_CTX} --persistent=0x81010
 tpm2_flushcontext --transient-object
 
 # Generating a key underneath the persistent, password protected, parent
-tpm2tss-genkey -a rsa -s 2048 -p def -P ${HANDLE} -W abc mykey
+tpm2tss-genkey -a rsa -s 2048 -p str:hex:DEADBEEF -P ${HANDLE} -W str:hex:CAFEBABE mykey
 
 cat > engine.conf <<EOF
     openssl_conf = openssl_init
@@ -29,15 +29,15 @@ cat > engine.conf <<EOF
     tpm2tss = tpm2tss_section
 
     [tpm2tss_section]
-    SET_PARENTAUTH = abc
+    SET_PARENTAUTH = str:hex:CAFEBABE
 EOF
 
 export OPENSSL_CONF=engine.conf
 
-echo def | openssl rsa -engine tpm2tss -inform engine -in mykey -pubout -outform pem -out mykey.pub -passin stdin
+echo str:hex:DEADBEEF | openssl rsa -engine tpm2tss -inform engine -in mykey -pubout -outform pem -out mykey.pub -passin stdin
 cat mykey.pub
 
-echo def | openssl pkeyutl -engine tpm2tss -keyform engine -inkey mykey -sign -in mydata.txt -out mysig -passin stdin
+echo str:hex:DEADBEEF | openssl pkeyutl -engine tpm2tss -keyform engine -inkey mykey -sign -in mydata.txt -out mysig -passin stdin
 
 # Release persistent HANDLE
 tpm2_evictcontrol --auth=o --handle=${HANDLE} --persistent=${HANDLE}

--- a/test/rsasign_parent_strstrpass.sh
+++ b/test/rsasign_parent_strstrpass.sh
@@ -9,7 +9,7 @@ echo "Generating primary key"
 PARENT_CTX=primary_owner_key.ctx
 
 tpm2_createprimary --hierarchy=o --halg=sha256 --kalg=rsa \
-                   --context=${PARENT_CTX} --pwdk=abc
+                   --context=${PARENT_CTX} --pwdk=str:str:abc
 tpm2_flushcontext --transient-object
 
 # Load primary key to persistent handle
@@ -17,7 +17,7 @@ HANDLE=$(tpm2_evictcontrol --auth=o --context=${PARENT_CTX} --persistent=0x81010
 tpm2_flushcontext --transient-object
 
 # Generating a key underneath the persistent, password protected, parent
-tpm2tss-genkey -a rsa -s 2048 -p def -P ${HANDLE} -W abc mykey
+tpm2tss-genkey -a rsa -s 2048 -p str:str:def -P ${HANDLE} -W str:str:abc mykey
 
 cat > engine.conf <<EOF
     openssl_conf = openssl_init
@@ -29,15 +29,15 @@ cat > engine.conf <<EOF
     tpm2tss = tpm2tss_section
 
     [tpm2tss_section]
-    SET_PARENTAUTH = abc
+    SET_PARENTAUTH = str:str:abc
 EOF
 
 export OPENSSL_CONF=engine.conf
 
-echo def | openssl rsa -engine tpm2tss -inform engine -in mykey -pubout -outform pem -out mykey.pub -passin stdin
+echo str:str:def | openssl rsa -engine tpm2tss -inform engine -in mykey -pubout -outform pem -out mykey.pub -passin stdin
 cat mykey.pub
 
-echo def | openssl pkeyutl -engine tpm2tss -keyform engine -inkey mykey -sign -in mydata.txt -out mysig -passin stdin
+echo str:str:def | openssl pkeyutl -engine tpm2tss -keyform engine -inkey mykey -sign -in mydata.txt -out mysig -passin stdin
 
 # Release persistent HANDLE
 tpm2_evictcontrol --auth=o --handle=${HANDLE} --persistent=${HANDLE}

--- a/test/rsasign_strhexpass.sh
+++ b/test/rsasign_strhexpass.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+
+set -eufx
+
+echo -n "abcde12345abcde12345">mydata
+
+tpm2tss-genkey -a rsa -s 2048 -p str:hex:DEADBEEF mykey
+
+echo str:hex:DEADBEEF | openssl rsa -engine tpm2tss -inform engine -in mykey -pubout -outform pem -out mykey.pub -passin stdin
+
+echo str:hex:DEADBEEF | openssl pkeyutl -engine tpm2tss -keyform engine -inkey mykey -sign -in mydata -out mysig -passin stdin
+
+#this is a workaround because -verify allways exits 1
+R="$(openssl pkeyutl -pubin -inkey mykey.pub -verify -in mydata -sigfile mysig || true)"
+if ! echo $R | grep "Signature Verified Successfully" >/dev/null; then
+    echo $R
+    exit 1
+fi

--- a/test/rsasign_strstrpass.sh
+++ b/test/rsasign_strstrpass.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+
+set -eufx
+
+echo -n "abcde12345abcde12345">mydata
+
+tpm2tss-genkey -a rsa -s 2048 -p str:str:abc mykey
+
+echo str:str:abc | openssl rsa -engine tpm2tss -inform engine -in mykey -pubout -outform pem -out mykey.pub -passin stdin
+
+echo str:str:abc | openssl pkeyutl -engine tpm2tss -keyform engine -inkey mykey -sign -in mydata -out mysig -passin stdin
+
+#this is a workaround because -verify allways exits 1
+R="$(openssl pkeyutl -pubin -inkey mykey.pub -verify -in mydata -sigfile mysig || true)"
+if ! echo $R | grep "Signature Verified Successfully" >/dev/null; then
+    echo $R
+    exit 1
+fi


### PR DESCRIPTION
Add ability to use binary passwords by passing them as a prefixed hex-string, much like the tpm2-tools package already supports. This includes both the tpm2tss-genkey tool and the SET_OWNERAUTH/SET_PARENTAUTH ctrls, where the ctrls also support directly using data not terminated by a null by passing the data length in the numeric argument of the ctrl.

#### Compatibility Analysis
There is a small chance the changes can break existing use-cases under some very specific circumstances:

1. For someone using a password starting with "hex:" or "str:". This applies to both the command-line options and the ENGINE ctrls. The alternative here would be to have separate command-line options and ctrls, but that would set the solution apart from what is currently done by tpm2-tools.

2. For someone using the ENGINE ctrls and passing a non-zero, non-strlen(), value as the numeric argument, even though it is currently unused. Since passing 0/NULL for unused arguments is established practice I don't see the risk of this being very high. The alternative would be to introduce separate ctrls with the new numeric argument behaviour.

All in all, my opinion is that the risks mentioned above are minimal and that keeping the interfaces similar to tpm2-tools is a higher goal in this instance, especially for (1). As mentioned in PR #134, writing a tpm2tss-engine.7 manpage is probably a good idea now that the ctrls are getting more complicated, I'll see if I can find the time to put one together and add to this PR if it is accepted. Let me know what you think!