### PR TITLE
A sample openssl.cnf file for the tpm2tss engine

### DIFF
--- a/openssl.conf.sample
+++ b/openssl.conf.sample
@@ -1,0 +1,22 @@
+openssl_conf = openssl_init
+
+[openssl_init]
+engines = engine_section
+
+[engine_section]
+tpm2tss = tpm2tss_section
+
+[tpm2tss_section]
+engine_id = tpm2tss
+dynamic_path = /usr/lib/engines-1.1/libtpm2tss.so
+default_algorithms = RSA,ECDSA
+init = 1
+#SET_TCTI = <TCTI_options>
+#SET_OWNERAUTH = <could_set_password_here, but then it's readable>
+#SET_PARENTAUTH = <password_of_parent_key> 
+
+[req]
+distinguished_name = subject
+
+[subject]
+# prompts and defaults here


### PR DESCRIPTION
I noticed issue #103. Here's a configuration file I was using recently. It can at least serve as a baseline for a `conf.sample`.

### Commit

* A sample openssl.cnf file for the tpm2tss engine

Configuration file can be used to pass additional arguments to engine.

A self-signed certificate for an RSA key can be issued with

    OPENSSL_CONF=openssl.conf openssl req -new -x509 -key rsa.tss -keyform engine -engine tpm2tss -out rsa.crt -subj <DN_here>

Fixes #103

Signed-off-by: Eero Aaltonen <eero.aaltonen@vaisala.com>