### PR TITLE
Add: import of TPM keys

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -116,6 +116,8 @@ TESTS_SHELL = test/ecdsa.sh \
               test/rsasign.sh \
               test/failload.sh \
               test/failwrite.sh \
+              test/rsasign_importtpm.sh \
+              test/rsasign_importtpmparent.sh \
               test/rsasign_parent.sh \
               test/rsasign_parent_pass.sh \
               test/rsasign_persistent.sh \

--- a/include/tpm2-tss-engine.h
+++ b/include/tpm2-tss-engine.h
@@ -64,6 +64,11 @@ tpm2tss_tpm2data_read(const char *filename, TPM2_DATA **tpm2Datap);
 int
 tpm2tss_tpm2data_readtpm(uint32_t handle, TPM2_DATA **tpm2Datap);
 
+int
+tpm2tss_tpm2data_importtpm(const char *filenamepub, const char *filenametpm,
+                           TPM2_HANDLE parent, int emptyAuth,
+                           TPM2_DATA **tpm2Datap);
+
 EVP_PKEY *
 tpm2tss_rsa_makekey(TPM2_DATA *tpm2Data);
 

--- a/man/tpm2tss-genkey.1.md
+++ b/man/tpm2tss-genkey.1.md
@@ -1,6 +1,6 @@
 % tpm2tss-genkey(1) tpm2-tss-engine | General Commands Manual
 %
-% JUNE 2018
+% MARCH 2019
 
 # NAME
 **tpm2tss-genkey**(1) -- generate TPM keys for tpm2-tss-engine
@@ -28,6 +28,12 @@ key information. This file can then be loaded with OpenSSL using
 
   * `-c <curve>`, `--curve <curve>`:
     If alg ecdsa is chosen, the curve for ecc (default: nist_p256)
+
+  * `-i <file>`, `--importpub <file>`:
+    Public key (TPM2B_PUBLIC) to be imported. Requires `-k`.
+
+  * `-k <file>`, `--importtpm <file>`:
+    The (encrypted) private key (TPM2B_PRIVATE) to be imported.
 
   * `-e <exponent>`, `--exponent <exponent>`:
     If alg rsa is chosen, the exponent for rsa (default: 65537)

--- a/src/tpm2tss-genkey.c
+++ b/src/tpm2tss-genkey.c
@@ -54,6 +54,8 @@ char *help =
     "    -c, --curve     curve for ecc (default: nist_p256)\n"
     "    -e, --exponent  exponent for rsa (default: 65537)\n"
     "    -h, --help      print help\n"
+    "    -i, --importpub Import a key and read its public portion from this file\n"
+    "    -k, --importtpm Read a TPM private key from this file for import\n"
     "    -o, --ownerpw   password for the owner hierarchy (default: none)\n"
     "    -p, --password  password for the created key (default: none)\n"
     "    -P, --parent    specific handle for the parent key (default: none)\n"
@@ -62,13 +64,15 @@ char *help =
     "    -W, --parentpw  password for the parent key (default: none)\n"
     "\n";
 
-static const char *optstr = "a:c:e:ho:p:P:s:vW:";
+static const char *optstr = "a:c:e:hi:k:o:p:P:s:vW:";
 
 static const struct option long_options[] = {
     {"alg",      required_argument, 0, 'a'},
     {"curve",    required_argument, 0, 'c'},
     {"exponent", required_argument, 0, 'e'},
     {"help",     no_argument,       0, 'h'},
+    {"importpub",required_argument, 0, 'i'},
+    {"importtpm",required_argument, 0, 'k'},
     {"ownerpw",  required_argument, 0, 'o'},
     {"password", required_argument, 0, 'p'},
     {"parent",   required_argument, 0, 'P'},
@@ -83,6 +87,8 @@ static struct opt {
     TPMI_ALG_PUBLIC alg;
     TPMI_ECC_CURVE curve;
     int exponent;
+    char *importpub;
+    char *importtpm;
     char *ownerpw;
     char *password;
     TPM2_HANDLE parent;
@@ -108,6 +114,8 @@ parse_opts(int argc, char **argv)
     opt.alg = TPM2_ALG_RSA;
     opt.curve = TPM2_ECC_NIST_P256;
     opt.exponent = 65537;
+    opt.importpub = NULL;
+    opt.importtpm = NULL;
     opt.ownerpw = NULL;
     opt.password = NULL;
     opt.parent = 0;
@@ -155,6 +163,12 @@ parse_opts(int argc, char **argv)
                 exit(1);
             }
             break;
+        case 'i':
+            opt.importpub = optarg;
+            break;
+        case 'k':
+            opt.importtpm = optarg;
+            break;
         case 'o':
             opt.ownerpw = optarg;
             break;
@@ -199,6 +213,12 @@ parse_opts(int argc, char **argv)
         ERR("%s", help);
         exit(1);
     }
+
+    if (opt.importpub && !opt.importtpm) {
+        ERR("--importpub requires --importtpm");
+        return 1;
+    }
+
     return 0;
 }
 
@@ -301,6 +321,7 @@ main(int argc, char **argv)
     if (parse_opts(argc, argv) != 0)
         exit(1);
 
+    int r;
     TPM2_DATA *tpm2Data = NULL;
 
     /* Initialize the tpm2-tss engine */
@@ -331,13 +352,19 @@ main(int argc, char **argv)
         return 1;
     }
 
-    /* Generate the key */
-    VERB("Generating the key\n");
-    switch (opt.alg) {
+    if (opt.importpub && opt.importtpm) {
+        VERB("Importing the TPM key\n");
+        r = tpm2tss_tpm2data_importtpm(opt.importpub, opt.importtpm, opt.parent,
+                                       opt.password == NULL, &tpm2Data);
+        if (r != 1)
+            return 1;
+    } else switch (opt.alg) {
     case TPM2_ALG_RSA:
+        VERB("Generating the rsa key\n");
         tpm2Data = genkey_rsa();
         break;
     case TPM2_ALG_ECDSA:
+        VERB("Generating the ecdsa key\n");
         tpm2Data = genkey_ecdsa();
         break;
     default:

--- a/test/rsasign_importtpm.sh
+++ b/test/rsasign_importtpm.sh
@@ -1,0 +1,36 @@
+#!/bin/bash
+
+set -eufx
+
+DIR=$(mktemp -d)
+TPM_RSA_PUBKEY=${DIR}/rsakey.pub
+TPM_RSA_KEY=${DIR}/rsakey
+PARENT_CTX=${DIR}/primary_owner_key.ctx
+
+echo -n "abcde12345abcde12345">${DIR}/mydata
+
+tpm2_startup -c || true
+
+# Create primary key as persistent handle
+tpm2_createprimary --hierarchy=o -g sha256 -G ecc --context=${PARENT_CTX} --object-attributes=decrypt\|fixedtpm\|fixedparent\|sensitivedataorigin\|userwithauth\|noda\|restricted
+tpm2_flushcontext -t
+
+# Create an RSA key pair
+echo "Generating RSA key pair"
+tpm2_create --pwdk=abc --context-parent=${PARENT_CTX} -g sha256 -G rsa \
+    --pubfile=${TPM_RSA_PUBKEY} --privfile=${TPM_RSA_KEY} \
+    --object-attributes=sign\|decrypt\|fixedtpm\|fixedparent\|sensitivedataorigin\|userwithauth\|noda
+tpm2_flushcontext -t
+
+tpm2tss-genkey -i ${TPM_RSA_PUBKEY} -k ${TPM_RSA_KEY} -p abc ${DIR}/mykey
+
+echo "abc" | openssl rsa -engine tpm2tss -inform engine -in ${DIR}/mykey -pubout -outform pem -out ${DIR}/mykey.pub -passin stdin
+
+echo "abc" | openssl pkeyutl -engine tpm2tss -keyform engine -inkey ${DIR}/mykey -sign -in ${DIR}/mydata -out ${DIR}/mysig -passin stdin
+
+#this is a workaround because -verify allways exits 1
+R="$(openssl pkeyutl -pubin -inkey ${DIR}/mykey.pub -verify -in ${DIR}/mydata -sigfile ${DIR}/mysig || true)"
+if ! echo $R | grep "Signature Verified Successfully" >/dev/null; then
+    echo $R
+    exit 1
+fi

--- a/test/rsasign_importtpmparent.sh
+++ b/test/rsasign_importtpmparent.sh
@@ -1,0 +1,44 @@
+#!/bin/bash
+
+set -eufx
+
+DIR=$(mktemp -d)
+TPM_RSA_PUBKEY=${DIR}/rsakey.pub
+TPM_RSA_KEY=${DIR}/rsakey
+PARENT_CTX=${DIR}/primary_owner_key.ctx
+
+echo -n "abcde12345abcde12345">${DIR}/mydata
+
+tpm2_startup -c || true
+
+# Create primary key as persistent handle
+tpm2_createprimary --hierarchy=o -g sha256 -G rsa --context=${PARENT_CTX}
+tpm2_flushcontext -t
+#tpm2_evictcontrol --auth=o --context=${PARENT_CTX} --persistent 0x81010003
+#tpm2_evictcontrol --auth=o --handle 0x81010003     --persistent 0x81010003
+#tpm2_flushcontext -t
+HANDLE=$(tpm2_evictcontrol --auth=o --context=${PARENT_CTX} --persistent 0x81010003 | cut -d ' ' -f 2)
+tpm2_flushcontext -t
+
+# Create an RSA key pair
+echo "Generating RSA key pair"
+tpm2_create --pwdk=abc --parent=${HANDLE} -g sha256 -G rsa \
+    --pubfile=${TPM_RSA_PUBKEY} --privfile=${TPM_RSA_KEY} \
+    --object-attributes=sign\|decrypt\|fixedtpm\|fixedparent\|sensitivedataorigin\|userwithauth\|noda
+tpm2_flushcontext -t
+
+tpm2tss-genkey -i ${TPM_RSA_PUBKEY} -k ${TPM_RSA_KEY} -p abc -P ${HANDLE} ${DIR}/mykey
+
+echo "abc" | openssl rsa -engine tpm2tss -inform engine -in ${DIR}/mykey -pubout -outform pem -out ${DIR}/mykey.pub -passin stdin
+
+echo "abc" | openssl pkeyutl -engine tpm2tss -keyform engine -inkey ${DIR}/mykey -sign -in ${DIR}/mydata -out ${DIR}/mysig -passin stdin
+
+# Release persistent HANDLE
+tpm2_evictcontrol --auth=o --handle 0x81010003     --persistent 0x81010003
+
+#this is a workaround because -verify allways exits 1
+R="$(openssl pkeyutl -pubin -inkey ${DIR}/mykey.pub -verify -in ${DIR}/mydata -sigfile ${DIR}/mysig || true)"
+if ! echo $R | grep "Signature Verified Successfully" >/dev/null; then
+    echo $R
+    exit 1
+fi


### PR DESCRIPTION
I have merged https://github.com/AndreasFuchsSIT/tpm2-tss-engine/commit/7f35306d7374940ff51f349965b67b83b4dabfd4 , removed -j option, and fixed testcases so that they works with tpm2-tools 3.2.1-rc0.

I confirmed that existing openssl-generated RSA keys can be imported with tpm2-tools-4.0-rc0 in this way:

`tpm2_createprimary -C o -g sha256 -G ecc -a "fixedtpm|fixedparent|sensitivedataorigin|noda|decrypt|restricted|userwithauth"  -c primary.ctx`
`tpm2_import -G rsa -g sha256 -i rsakey.pem -C primary.ctx -u tpmkey.pub -r tpmkey.priv`
`tpm2tss-genkey -i tpmkey.pub -k tpmkey.priv  rsakey.tss`

I did not added testcase for this though since it requires migration to tpm2-tools-4.0, which breaks other testcases.
so Issue #39 could be closed after migration to tpm2-tools-4.0.
