### PR TITLE
test: use tpm2-tools 4.X

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,9 +7,9 @@ dist: xenial
 
 env:
   matrix:
-  - OPENSSL_BRANCH=OpenSSL_1_0_2-stable TPM2TSS_BRANCH=2.2.x TPM2TOOLS_BRANCH=3.X
-  - OPENSSL_BRANCH=OpenSSL_1_1_0-stable TPM2TSS_BRANCH=2.2.x TPM2TOOLS_BRANCH=3.X
-  - OPENSSL_BRANCH=OpenSSL_1_1_1-stable TPM2TSS_BRANCH=2.2.x TPM2TOOLS_BRANCH=3.X
+  - OPENSSL_BRANCH=OpenSSL_1_0_2-stable TPM2TSS_BRANCH=2.3.x TPM2TOOLS_BRANCH=4.X
+  - OPENSSL_BRANCH=OpenSSL_1_1_0-stable TPM2TSS_BRANCH=2.3.x TPM2TOOLS_BRANCH=4.X
+  - OPENSSL_BRANCH=OpenSSL_1_1_1-stable TPM2TSS_BRANCH=2.3.x TPM2TOOLS_BRANCH=4.X
   global:
   - TPM2TOOLS_TCTI=mssim
   - PATH="${PWD}/installdir/usr/local/bin:${PATH}"
@@ -63,6 +63,7 @@ install:
   - git clone --depth=1 -b ${TPM2TSS_BRANCH} https://github.com/tpm2-software/tpm2-tss.git
   - pushd tpm2-tss
   - cp ../autoconf-archive-2017.09.28/m4/ax_code_coverage.m4 m4/
+  - cp ../autoconf-archive-2017.09.28/m4/ax_is_release.m4 m4/
   - cp ../autoconf-archive-2017.09.28/m4/ax_prog_doxygen.m4 m4/
   - ./bootstrap
   - ./configure CFLAGS=-I${PWD}/../installdir/usr/local/include LDFLAGS=-L${PWD}/../installdir/usr/local/lib --disable-doxygen-doc
@@ -74,7 +75,7 @@ install:
   - git clone --depth=1 -b ${TPM2TOOLS_BRANCH} https://github.com/tpm2-software/tpm2-tools.git
   - pushd tpm2-tools
   - mkdir m4 || true
-  - cp ../autoconf-archive-2017.09.28/m4/ax_code_coverage.m4 m4/
+  - cp ../autoconf-archive-2017.09.28/m4/ax_code_coverage.m4 ../autoconf-archive-2017.09.28/m4/ax_is_release.m4 m4/
   - ./bootstrap
   # Some workarounds for tpm2-tools with -Wno-XXX
   - ./configure --disable-hardening CFLAGS="-I${PWD}/../installdir/usr/local/include -Wno-unused-value -Wno-missing-field-initializer" LDFLAGS=-L${PWD}/../installdir/usr/local/lib

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -14,7 +14,7 @@
 
 Integration tests also require:
 * expect
-* tpm2-tools 3.2 (or 3.X branch)
+* tpm2-tools 4.0 (or 4.X branch)
 * tpm_server
 * realpath
 * ss

--- a/test/rsasign_parent.sh
+++ b/test/rsasign_parent.sh
@@ -8,12 +8,12 @@ echo -n "abcde12345abcde12345">mydata.txt
 echo "Generating primary key"
 PARENT_CTX=primary_owner_key.ctx
 
-tpm2_createprimary --hierarchy=o --halg=sha256 --kalg=rsa \
-                   --context=${PARENT_CTX}
+tpm2_createprimary --hierarchy=o --hash-algorithm=sha256 --key-algorithm=rsa \
+                   --key-context=${PARENT_CTX}
 tpm2_flushcontext --transient-object
 
 # Load primary key to persistent handle
-HANDLE=$(tpm2_evictcontrol --auth=o --context=${PARENT_CTX} --persistent=0x81010001 | cut -d ' ' -f 2 | head -n 1)
+HANDLE=$(tpm2_evictcontrol --hierarchy=o --object-context=${PARENT_CTX} | cut -d ' ' -f 2 | head -n 1)
 tpm2_flushcontext --transient-object
 
 # Generating a key underneath the persistent parent
@@ -25,7 +25,7 @@ cat mykey.pub
 echo "abc" | openssl pkeyutl -engine tpm2tss -keyform engine -inkey mykey -sign -in mydata.txt -out mysig -passin stdin
 
 # Release persistent HANDLE
-tpm2_evictcontrol --auth=o --handle=${HANDLE} --persistent=${HANDLE}
+tpm2_evictcontrol --hierarchy=o --object-context=${HANDLE}
 
 #this is a workaround because -verify allways exits 1
 R="$(openssl pkeyutl -pubin -inkey mykey.pub -verify -in mydata.txt -sigfile mysig || true)"

--- a/test/rsasign_parent_pass.sh
+++ b/test/rsasign_parent_pass.sh
@@ -8,12 +8,12 @@ echo -n "abcde12345abcde12345">mydata.txt
 echo "Generating primary key"
 PARENT_CTX=primary_owner_key.ctx
 
-tpm2_createprimary --hierarchy=o --halg=sha256 --kalg=rsa \
-                   --context=${PARENT_CTX} --pwdk=abc
+tpm2_createprimary --hierarchy=o --hash-algorithm=sha256 --key-algorithm=rsa \
+                   --key-context=${PARENT_CTX} --key-auth=abc
 tpm2_flushcontext --transient-object
 
 # Load primary key to persistent handle
-HANDLE=$(tpm2_evictcontrol --auth=o --context=${PARENT_CTX} --persistent=0x81010001 | cut -d ' ' -f 2 | head -n 1)
+HANDLE=$(tpm2_evictcontrol --hierarchy=o --object-context=${PARENT_CTX} | cut -d ' ' -f 2 | head -n 1)
 tpm2_flushcontext --transient-object
 
 # Generating a key underneath the persistent, password protected, parent
@@ -40,7 +40,7 @@ cat mykey.pub
 echo "abc" | openssl pkeyutl -engine tpm2tss -keyform engine -inkey mykey -sign -in mydata.txt -out mysig -passin stdin
 
 # Release persistent HANDLE
-tpm2_evictcontrol --auth=o --handle=${HANDLE} --persistent=${HANDLE}
+tpm2_evictcontrol --hierarchy=o --object-context=${HANDLE}
 
 #this is a workaround because -verify allways exits 1
 R="$(openssl pkeyutl -pubin -inkey mykey.pub -verify -in mydata.txt -sigfile mysig || true)"

--- a/test/rsasign_persistent.sh
+++ b/test/rsasign_persistent.sh
@@ -8,38 +8,38 @@ echo -n "abcde12345abcde12345">mydata.txt
 echo "Generating primary key"
 PARENT_CTX=primary_owner_key.ctx
 
-tpm2_createprimary --hierarchy=o --halg=sha256 --kalg=rsa \
-                   --context=${PARENT_CTX}
+tpm2_createprimary --hierarchy=o --hash-algorithm=sha256 --key-algorithm=rsa \
+                   --key-context=${PARENT_CTX}
 tpm2_flushcontext --transient-object
 
 # Create an RSA key pair
 echo "Generating RSA key pair"
 TPM_RSA_PUBKEY=rsakey.pub
 TPM_RSA_KEY=rsakey
-tpm2_create --pwdk=abc \
-            --context-parent=${PARENT_CTX} \
-            --halg=sha256 --kalg=rsa \
-            --pubfile=${TPM_RSA_PUBKEY} --privfile=${TPM_RSA_KEY} \
-            --object-attributes=sign\|decrypt\|fixedtpm\|fixedparent\|sensitivedataorigin\|userwithauth\|noda
+tpm2_create --key-auth=abc \
+            --parent-context=${PARENT_CTX} \
+            --hash-algorithm=sha256 --key-algorithm=rsa \
+            --public=${TPM_RSA_PUBKEY} --private=${TPM_RSA_KEY} \
+            --attributes=sign\|decrypt\|fixedtpm\|fixedparent\|sensitivedataorigin\|userwithauth\|noda
 tpm2_flushcontext --transient-object
 
 # Load Key to persistent handle
 RSA_CTX=rsakey.ctx
-tpm2_load --context-parent=${PARENT_CTX} \
-          --pubfile=${TPM_RSA_PUBKEY} --privfile=${TPM_RSA_KEY} \
-          --context=${RSA_CTX}
+tpm2_load --parent-context=${PARENT_CTX} \
+          --public=${TPM_RSA_PUBKEY} --private=${TPM_RSA_KEY} \
+          --key-context=${RSA_CTX}
 tpm2_flushcontext --transient-object
 
-HANDLE=$(tpm2_evictcontrol --auth=o --context=${RSA_CTX} --persistent=0x81010001 | cut -d ' ' -f 2 | head -n 1)
+HANDLE=$(tpm2_evictcontrol --hierarchy=o --object-context=${RSA_CTX} | cut -d ' ' -f 2 | head -n 1)
 tpm2_flushcontext --transient-object
 
 # Signing Data
 echo "abc" | openssl pkeyutl -engine tpm2tss -keyform engine -inkey ${HANDLE} -sign -in mydata.txt -out mysig -passin stdin
 # Get public key of handle
-tpm2_readpublic --object=${HANDLE} --opu=mykey.pem --format=pem
+tpm2_readpublic --object-context=${HANDLE} --output=mykey.pem --format=pem
 
 # Release persistent HANDLE
-tpm2_evictcontrol --auth=o --handle=${HANDLE} --persistent=${HANDLE}
+tpm2_evictcontrol --hierarchy=o --object-context=${HANDLE}
 
 R="$(openssl pkeyutl -pubin -inkey mykey.pem -verify -in mydata.txt -sigfile mysig || true)"
 if ! echo $R | grep "Signature Verified Successfully" >/dev/null; then

--- a/test/rsasign_persistent_emptyauth.sh
+++ b/test/rsasign_persistent_emptyauth.sh
@@ -8,28 +8,28 @@ echo -n "abcde12345abcde12345">mydata.txt
 echo "Generating primary key"
 PARENT_CTX=primary_owner_key.ctx
 
-tpm2_createprimary --hierarchy=o --halg=sha256 --kalg=rsa \
-                   --context=${PARENT_CTX}
+tpm2_createprimary --hierarchy=o --hash-algorithm=sha256 --key-algorithm=rsa \
+                   --key-context=${PARENT_CTX}
 tpm2_flushcontext --transient-object
 
 # Create an RSA key pair
 echo "Generating RSA key pair"
 TPM_RSA_PUBKEY=rsakey.pub
 TPM_RSA_KEY=rsakey
-tpm2_create --context-parent=${PARENT_CTX} \
-            --halg=sha256 --kalg=rsa \
-            --pubfile=${TPM_RSA_PUBKEY} --privfile=${TPM_RSA_KEY} \
-            --object-attributes=sign\|decrypt\|fixedtpm\|fixedparent\|sensitivedataorigin\|userwithauth\|noda
+tpm2_create --parent-context=${PARENT_CTX} \
+            --hash-algorithm=sha256 --key-algorithm=rsa \
+            --public=${TPM_RSA_PUBKEY} --private=${TPM_RSA_KEY} \
+            --attributes=sign\|decrypt\|fixedtpm\|fixedparent\|sensitivedataorigin\|userwithauth\|noda
 tpm2_flushcontext --transient-object
 
 # Load Key to persistent handle
 RSA_CTX=rsakey.ctx
-tpm2_load --context-parent=${PARENT_CTX} \
-          --pubfile=${TPM_RSA_PUBKEY} --privfile=${TPM_RSA_KEY} \
-          --context=${RSA_CTX}
+tpm2_load --parent-context=${PARENT_CTX} \
+          --public=${TPM_RSA_PUBKEY} --private=${TPM_RSA_KEY} \
+          --key-context=${RSA_CTX}
 tpm2_flushcontext --transient-object
 
-HANDLE=$(tpm2_evictcontrol --auth=o --context=${RSA_CTX} --persistent=0x81010001 | cut -d ' ' -f 2 | head -n 1)
+HANDLE=$(tpm2_evictcontrol --hierarchy=o --object-context=${RSA_CTX} | cut -d ' ' -f 2 | head -n 1)
 tpm2_flushcontext --transient-object
 
 # Signing Data
@@ -45,10 +45,10 @@ EOF
 fi
 
 # Get public key of handle
-tpm2_readpublic --object=${HANDLE} --opu=mykey.pem --format=pem
+tpm2_readpublic --object-context=${HANDLE} --output=mykey.pem --format=pem
 
 # Release persistent HANDLE
-tpm2_evictcontrol --auth=o --handle=${HANDLE} --persistent=${HANDLE}
+tpm2_evictcontrol --hierarchy=o --object-context=${HANDLE}
 
 R="$(openssl pkeyutl -pubin -inkey mykey.pem -verify -in mydata.txt -sigfile mysig || true)"
 if ! echo $R | grep "Signature Verified Successfully" >/dev/null; then


### PR DESCRIPTION
Since tpm2-tools 4.0 has been released, we can update our tests. tpm2-tools 4.0 also requires tpm2-tss 2.3, so bump that as well.