### PR TITLE
TEST: Enable integration tests with physical TPMS.

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -130,6 +130,7 @@ TESTS_SHELL = test/ecdsa.sh \
 EXTRA_DIST += $(TESTS_SHELL)
 TEST_EXTENSIONS = .sh
 SH_LOG_COMPILER = $(srcdir)/test/sh_log_compiler.sh
+SH_LOG_FLAGS = $(INTEGRATION_ARGS)
 EXTRA_DIST += $(SH_LOG_COMPILER)
 
 if UNIT

--- a/configure.ac
+++ b/configure.ac
@@ -164,8 +164,22 @@ AC_ARG_ENABLE([integration],
                             [build integration tests against TPM])],,
             [enable_integration=no])
 AM_CONDITIONAL([INTEGRATION], [test "x$enable_integration" != xno])
-AS_IF([test "x$enable_integration" = xyes],
-      [AC_CHECK_PROG([tpm2_startup], [tpm2_startup], [yes])
+
+# Use physical TPM device for testing
+AC_ARG_WITH([device],
+            [AS_HELP_STRING([--with-device=<device>],[TPM device for testing])],
+            [AS_IF([test \( -w "$with_device" \)  -a \( -r "$with_device" \)],
+                   [AC_MSG_RESULT([success])
+                    AX_NORMALIZE_PATH([with_device])
+                    with_device_set=yes],
+                   [AC_MSG_ERROR([TPM device provided does not exist or is not writable])])],
+            [with_device_set=no])
+AM_CONDITIONAL([TESTDEVICE],[test "x$with_device_set" = xyes])
+
+# Integration test with simulator
+AS_IF([test "x$enable_integration" = xyes && test "x$with_device_set" = xno],
+      [integration_args=""
+       AC_CHECK_PROG([tpm2_startup], [tpm2_startup], [yes])
        AS_IF([test "x$tpm2_startup" != xyes],
              [AC_MSG_ERROR([Integration tests require the tpm2_startup executable])])
        AC_CHECK_PROG([tpm_server], [tpm_server], [yes])
@@ -179,6 +193,18 @@ AS_IF([test "x$enable_integration" = xyes],
              [AC_MSG_ERROR([Integration tests require the ss executable])])
        AS_IF([test "x$enable_tctienvvar" != xyes],
              [AC_MSG_ERROR([Integration tests require building with TCTI environment variable support])])
+       AC_SUBST([INTEGRATION_ARGS], [$integration_args])
+      ])
+
+# Integration test with physical device
+AS_IF([test "x$enable_integration" = xyes &&  test "x$with_device_set" = xyes ],
+      [integration_args="$with_device"
+       AC_CHECK_PROG([realpath], [realpath], [yes])
+       AS_IF([test "x$realpath" != xyes],
+             [AC_MSG_ERROR([Integration tests require the realpath executable])])
+       AS_IF([test "x$enable_tctienvvar" != xyes],
+             [AC_MSG_ERROR([Integration tests require building with TCTI environment variable support])])
+       AC_SUBST([INTEGRATION_ARGS], [$integration_args])
       ])
 
 AX_VALGRIND_CHECK
@@ -214,5 +240,6 @@ $PACKAGE_NAME $VERSION
     man-pages:      $PANDOC
     enginesdir:     $with_enginesdir
     completionsdir: $with_completionsdir
+    device:         $with_device
 ])
-    
+

--- a/test/sh_log_compiler.sh
+++ b/test/sh_log_compiler.sh
@@ -5,7 +5,13 @@ export OPENSSL_ENGINES="${OPENSSL_ENGINES:=$PWD/.libs}"
 export LD_LIBRARY_PATH="$OPENSSL_ENGINES:${LD_LIBRARY_PATH-}"
 export PATH="$PWD:$PATH"
 
-test_script="$(realpath "$1")"
+if [ -z "$2" ]; then
+    # no device passed
+    test_script="$(realpath "$1")"
+else
+    test_script="$(realpath "$2")"
+    INTEGRATION_DEVICE=$1
+fi
 
 echo "Creating tpm2tss symlink"
 ln -fs libtpm2tss.so .libs/tpm2tss.so
@@ -14,33 +20,41 @@ tmp_dir="$(mktemp --directory)"
 echo "Switching to temporary directory $tmp_dir"
 cd "$tmp_dir"
 
-for attempt in $(seq 9 -1 0); do
-    tpm_server_port="$(shuf --input-range 1024-65534 --head-count 1)"
-    echo "Starting simulator on port $tpm_server_port"
-    tpm_server -port "$tpm_server_port" &
-    tpm_server_pid="$!"
-    sleep 1
+if [ -z "$INTEGRATION_DEVICE" ]; then
+   # No device is passed so the TPM simulator will be used.
+   for attempt in $(seq 9 -1 0); do
+       tpm_server_port="$(shuf --input-range 1024-65534 --head-count 1)"
+       echo "Starting simulator on port $tpm_server_port"
+       tpm_server -port "$tpm_server_port" &
+       tpm_server_pid="$!"
+       sleep 1
 
-    if ( ss --listening --tcp --ipv4 --processes | grep "$tpm_server_pid" | grep --quiet "$tpm_server_port" &&
-         ss --listening --tcp --ipv4 --processes | grep "$tpm_server_pid" | grep --quiet "$(( tpm_server_port + 1 ))" )
-    then
-        echo "Simulator with PID $tpm_server_pid started successfully"
-        break
-    else
-        echo "Failed to start simulator, the port might be in use"
-        kill "$tpm_server_pid"
+       if ( ss --listening --tcp --ipv4 --processes | grep "$tpm_server_pid" | grep --quiet "$tpm_server_port" &&
+            ss --listening --tcp --ipv4 --processes | grep "$tpm_server_pid" | grep --quiet "$(( tpm_server_port + 1 ))" )
+       then
+           echo "Simulator with PID $tpm_server_pid started successfully"
+           break
+       else
+           echo "Failed to start simulator, the port might be in use"
+           kill "$tpm_server_pid"
 
-        if [ "$attempt" -eq 0 ]; then
-            echo 'ERROR: Reached maximum number of tries to start simulator, giving up'
-            exit 99
-        fi
-    fi
-done
+           if [ "$attempt" -eq 0 ]; then
+               echo 'ERROR: Reached maximum number of tries to start simulator, giving up'
+               exit 99
+           fi
+       fi
+   done
 
-export TPM2TSSENGINE_TCTI="libtss2-tcti-mssim.so:port=$tpm_server_port"
-export TPM2TOOLS_TCTI="$TPM2TSSENGINE_TCTI"
+   export TPM2TSSENGINE_TCTI="libtss2-tcti-mssim.so:port=$tpm_server_port"
+   export TPM2TOOLS_TCTI="$TPM2TSSENGINE_TCTI"
 
-tpm2_startup --clear
+   tpm2_startup --clear
+else
+    # A physical TPM will be used for the integration test.
+    echo "Running the test with $INTEGRATION_DEVICE"
+    export TPM2TSSENGINE_TCTI="libtss2-tcti-device.so:$INTEGRATION_DEVICE"
+    export TPM2TOOLS_TCTI="$TPM2TSSENGINE_TCTI"
+fi
 
 echo "Starting $test_script"
 "$test_script"


### PR DESCRIPTION
* The configure option --with-device=<tpm device> was added to switch from simulator tests to
  tests with physical TPMS.
* The sh-log-compiler script was adapted.

Signed-off-by: Juergen Repp <juergen.repp@sit.fraunhofer.de>