### PR TITLE
Support ossl engine config

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,3 +42,4 @@ man/*.7
 *~
 test/error_tpm2-tss-engine-common
 test/*.o
+config.h.in

--- a/configure.ac
+++ b/configure.ac
@@ -57,6 +57,8 @@ AM_INIT_AUTOMAKE([foreign subdir-objects -Wall -Wno-portability])
 m4_ifdef([AM_SILENT_RULES], [AM_SILENT_RULES([yes])]) 
 AM_MAINTAINER_MODE([enable])
 
+AX_CHECK_ENABLE_DEBUG([info])
+
 AC_PROG_CC
 AC_PROG_CC_C99
 AM_PROG_CC_C_O
@@ -65,13 +67,14 @@ LT_INIT()
 AC_PROG_MKDIR_P
 AC_PROG_LN_S
 
-AX_CHECK_ENABLE_DEBUG([info])
+AC_CONFIG_HEADERS([src/config.h])
 
 AC_ARG_ENABLE([tctienvvar],
     [AS_HELP_STRING([--disable-tctienvvar],
                     [Disable setting the TCTI option from an environment variable])],,
     [enable_tctienvvar=yes])
-AS_IF([test "x$enable_tctienvvar" = xyes], [AC_DEFINE([ENABLE_TCTIENVVAR], [1])])
+AS_IF([test "x$enable_tctienvvar" = xyes], [AC_DEFINE([ENABLE_TCTIENVVAR], [1],
+      'Enable getting TCTI from env variable')])
 
 AC_CONFIG_FILES([Makefile])
 

--- a/configure.ac
+++ b/configure.ac
@@ -65,12 +65,7 @@ LT_INIT()
 AC_PROG_MKDIR_P
 AC_PROG_LN_S
 
-AC_ARG_ENABLE([debug],
-            [AS_HELP_STRING([--enable-debug],
-                            [build with debug output])],,
-            [enable_debug=no])
-AS_IF([test "x$enable_debug" != "xno"],
-      AC_DEFINE_UNQUOTED([DEBUG], [1], ["Debug output enabled"]))
+AX_CHECK_ENABLE_DEBUG([info])
 
 AC_ARG_ENABLE([tctienvvar],
     [AS_HELP_STRING([--disable-tctienvvar],

--- a/man/tpm2tss-genkey.1.md
+++ b/man/tpm2tss-genkey.1.md
@@ -58,6 +58,10 @@ key information. This file can then be loaded with OpenSSL using
     Password for the parent key (default: none)
     Openssl Config control command: `SET_PARENTAUTH`
 
+  * `-t <tcti-conf>`, `--tcti <tcti-conf>`:
+    TCTI Configuration string (default: none)
+    Openssl Config control command: `SET_TCTI`
+
 # EXAMPLES
 
 Engine informations can be retrieved using:

--- a/man/tpm2tss-genkey.1.md
+++ b/man/tpm2tss-genkey.1.md
@@ -15,6 +15,9 @@
 tpm2tss software stack. Those keys may be an RSA key for decryption or signing
 or an ECC key for ECDSA signatures.
 
+The tool respects the OPENSSL_CONF option for specifying engine specific control
+parameters. See `man(5) config` for details on openssl config files.
+
 # ARGUMENTS
 
 The `tpm2tss-genkey` command expects a filename for storing the resulting TPM
@@ -37,6 +40,7 @@ key information. This file can then be loaded with OpenSSL using
 
   * `-o <password>`, `--ownerpw <password>`:
     Password for the owner hierarchy (default: none)
+    Openssl Config control command: `SET_OWNERAUTH`
 
   * `-p <password>`, `--password <password>`:
     Password for the created key (default: none)
@@ -52,6 +56,7 @@ key information. This file can then be loaded with OpenSSL using
 
   * `-W <password>`, `--parentpw <password>`:
     Password for the parent key (default: none)
+    Openssl Config control command: `SET_PARENTAUTH`
 
 # EXAMPLES
 

--- a/src/tpm2-tss-engine-err.h
+++ b/src/tpm2-tss-engine-err.h
@@ -31,6 +31,8 @@
 #ifndef TPM2_TSS_ENGINE_ERR_H
 #define TPM2_TSS_ENGINE_ERR_H
 
+#include "config.h"
+
 #include <stdint.h>
 
 #ifndef NDEBUG

--- a/src/tpm2-tss-engine-err.h
+++ b/src/tpm2-tss-engine-err.h
@@ -33,7 +33,7 @@
 
 #include <stdint.h>
 
-#ifdef DEBUG
+#ifndef NDEBUG
 #define DBG(...) fprintf(stderr, __VA_ARGS__)
 #define DBGBUF(...) printbuf(__VA_ARGS__)
 void printbuf(const uint8_t *b, size_t s);

--- a/src/tpm2-tss-engine.c
+++ b/src/tpm2-tss-engine.c
@@ -270,7 +270,9 @@ init_engine(ENGINE *e) {
 #ifdef ENABLE_TCTIENVVAR
     /*  Set the default TCTI option from the environment */
     OPENSSL_free(tcti_nameconf);
-    tcti_nameconf = OPENSSL_strdup(getenv("TPM2TSSENGINE_TCTI"));
+    if (getenv("TPM2TSSENGINE_TCTI")) {
+        tcti_nameconf = OPENSSL_strdup(getenv("TPM2TSSENGINE_TCTI"));
+    }
 #endif
 
     rc = init_rand(e);

--- a/src/tpm2-tss-engine.c
+++ b/src/tpm2-tss-engine.c
@@ -28,6 +28,7 @@
  * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
  * THE POSSIBILITY OF SUCH DAMAGE.
  ******************************************************************************/
+#include "config.h"
 
 #include <stdlib.h>
 #include <string.h>

--- a/src/tpm2tss-genkey.c
+++ b/src/tpm2tss-genkey.c
@@ -34,6 +34,7 @@
 #include <inttypes.h>
 #include <getopt.h>
 
+#include <openssl/conf.h>
 #include <openssl/engine.h>
 #include <openssl/pem.h>
 
@@ -302,6 +303,12 @@ main(int argc, char **argv)
         exit(1);
 
     TPM2_DATA *tpm2Data = NULL;
+
+#if OPENSSL_VERSION_NUMBER < 0x1010000fL
+    OPENSSL_config(NULL);
+#else
+    OPENSSL_init_crypto(OPENSSL_INIT_LOAD_CONFIG, NULL);
+#endif
 
     /* Initialize the tpm2-tss engine */
     ENGINE_load_dynamic();

--- a/src/tpm2tss-genkey.c
+++ b/src/tpm2tss-genkey.c
@@ -334,7 +334,8 @@ main(int argc, char **argv)
         return 1;
     }
 
-    if (!ENGINE_ctrl(tpm_engine, TPM2TSS_SET_PARENTAUTH, 0, opt.parentpw, NULL)) {
+    if (opt.parentpw &&
+            !ENGINE_ctrl(tpm_engine, TPM2TSS_SET_PARENTAUTH, 0, opt.parentpw, NULL)) {
         ERR("Could not set parentauth\n");
         return 1;
     }

--- a/src/tpm2tss-genkey.c
+++ b/src/tpm2tss-genkey.c
@@ -61,9 +61,10 @@ char *help =
     "    -s, --keysize   key size in bits for rsa (default: 2048)\n"
     "    -v, --verbose   print verbose messages\n"
     "    -W, --parentpw  password for the parent key (default: none)\n"
-    "\n";
+    "    -t, --tcti      tcti configuration string (default: none)\n"
+		"\n";
 
-static const char *optstr = "a:c:e:ho:p:P:s:vW:";
+static const char *optstr = "a:c:e:ho:p:P:s:vW:t:";
 
 static const struct option long_options[] = {
     {"alg",      required_argument, 0, 'a'},
@@ -76,6 +77,7 @@ static const struct option long_options[] = {
     {"keysize",  required_argument, 0, 's'},
     {"verbose",  no_argument,       0, 'v'},
     {"parentpw", required_argument, 0, 'W'},
+    {"tcti",     required_argument, 0, 't'},
     {0,          0,                 0,  0 }
 };
 
@@ -90,6 +92,7 @@ static struct opt {
     char *parentpw;
     int keysize;
     int verbose;
+    char *tcti_conf;
 } opt;
 
 /** Parse and set command line options.
@@ -115,6 +118,7 @@ parse_opts(int argc, char **argv)
     opt.parentpw = NULL;
     opt.keysize = 2048;
     opt.verbose = 0;
+    opt.tcti_conf = NULL;
 
     /* parse the options */
     int c;
@@ -178,6 +182,9 @@ parse_opts(int argc, char **argv)
                 ERR("Error parsing keysize.\n");
                 exit(1);
             }
+            break;
+        case 't':
+            opt.tcti_conf = optarg;
             break;
         default:
             ERR("Unknown option at index %i.\n\n", opt_idx);
@@ -336,6 +343,12 @@ main(int argc, char **argv)
 
     if (opt.parentpw &&
             !ENGINE_ctrl(tpm_engine, TPM2TSS_SET_PARENTAUTH, 0, opt.parentpw, NULL)) {
+        ERR("Could not set parentauth\n");
+        return 1;
+    }
+
+    if (opt.tcti_conf &&
+            !ENGINE_ctrl(tpm_engine, TPM2TSS_SET_TCTI, 0, opt.tcti_conf, NULL)) {
         ERR("Could not set parentauth\n");
         return 1;
     }

--- a/src/tpm2tss-genkey.c
+++ b/src/tpm2tss-genkey.c
@@ -328,7 +328,8 @@ main(int argc, char **argv)
     if (!init_res)
         return 1;
 
-    if (!ENGINE_ctrl(tpm_engine, TPM2TSS_SET_OWNERAUTH, 0, opt.ownerpw, NULL)) {
+    if (opt.ownerpw &&
+            !ENGINE_ctrl(tpm_engine, TPM2TSS_SET_OWNERAUTH, 0, opt.ownerpw, NULL)) {
         ERR("Could not set ownerauth\n");
         return 1;
     }


### PR DESCRIPTION
The library has two methods of controling the TCTI, one is via an env variable, the other is through the engine control interface. Unify these so the tpm2tss-genkey will support eithir method.

This patch series adds support for openssl config to be understood by this tool as well as exposing the tcti option via -t to override the config file. It also changes the other options to override only when set.
