### PR TITLE
tpm2tss-genkey: If parent of key is OWNER, save that to file (not 0).

### DIFF
--- a/src/tpm2-tss-engine-common.c
+++ b/src/tpm2-tss-engine-common.c
@@ -171,7 +171,11 @@ tpm2tss_tpm2data_write(const TPM2_DATA *tpm2Data, const char *filename)
     }
 
     tpk->emptyAuth = ! !tpm2Data->emptyAuth;
-    ASN1_INTEGER_set(tpk->parent, tpm2Data->parent);
+    if (tpm2Data->parent != 0) {
+        ASN1_INTEGER_set(tpk->parent, tpm2Data->parent);
+    } else {
+        ASN1_INTEGER_set(tpk->parent, TPM2_RH_OWNER);
+    }
     ASN1_STRING_set(tpk->privkey, &privbuf[0], privbuf_len);
     ASN1_STRING_set(tpk->pubkey, &pubbuf[0], pubbuf_len);
 


### PR DESCRIPTION
If I understand correctly, the `tpm2tss_tpm2data_read` function treats a `parent` value of `0` in a `BEGIN TSS2 PRIVATE KEY` PEM file as equivalent to a `parent` value of `TPM2_RH_OWNER`. Similarly, the `tpm2-genkey` utility uses a value of `0` for the `parentHandle` if not explicitly specified.

However, this causes difficulty if a key is generated using the `tpm-genkey` utility but then loaded using a different OpenSSL engine (for example @jejb's `tpm2` engine), because the other engine doesn't recognize `0` as a valid parent value.

Of course, it's currently possible to work around this by specifying an explicit `-P 0x40000001` to the `tpm2-genkey` command. However, that puts the burden on the caller to remember to not use the default, even though semantically they should be able to use it (and, the TPM handles aren't exactly easy to remember...).

To help with this in a backward-compatible way, this patch writes private keys to file with an explicit `TPM2_RH_OWNER` as `parent` if the parent is `0`.

I apologize if there's context here that I don't know and writing the `parent` as `0` is in fact valid/necessary.