### PR TITLE
test: add support for swtpm simulator

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,11 +7,10 @@ dist: xenial
 
 env:
   matrix:
-  - OPENSSL_BRANCH=OpenSSL_1_0_2-stable TPM2TSS_BRANCH=2.3.x TPM2TOOLS_BRANCH=4.0
-  - OPENSSL_BRANCH=OpenSSL_1_1_0-stable TPM2TSS_BRANCH=2.3.x TPM2TOOLS_BRANCH=4.0
-  - OPENSSL_BRANCH=OpenSSL_1_1_1-stable TPM2TSS_BRANCH=2.3.x TPM2TOOLS_BRANCH=4.0
+  - OPENSSL_BRANCH=OpenSSL_1_0_2-stable TPM2TSS_BRANCH=3.0.x TPM2TOOLS_BRANCH=4.0
+  - OPENSSL_BRANCH=OpenSSL_1_1_0-stable TPM2TSS_BRANCH=3.0.x TPM2TOOLS_BRANCH=4.0
+  - OPENSSL_BRANCH=OpenSSL_1_1_1-stable TPM2TSS_BRANCH=3.0.x TPM2TOOLS_BRANCH=4.0
   global:
-  - TPM2TOOLS_TCTI=mssim
   - PATH="${PWD}/installdir/usr/local/bin:${PATH}"
   - PKG_CONFIG_PATH="${PWD}/installdir/usr/local/lib/pkgconfig:/usr/lib/pkgconfig"
   - LD_LIBRARY_PATH="${PWD}/installdir/usr/local/lib:/usr/lib"
@@ -32,10 +31,28 @@ addons:
     - pandoc
     - expect
     - doxygen
+    - libjson-c-dev
+    - libtasn1-dev
+    - socat
+    - python3-setuptools
+    - libseccomp-dev
 
 install:
   - git clean -xdf
   - mkdir -p installdir/usr/local/bin
+# TPM Simulator
+  - git clone --branch=v0.7.3 --depth=1 https://github.com/stefanberger/libtpms.git
+  - pushd libtpms
+  - autoreconf --install --force
+  - ./configure --prefix="$PWD/../installdir/usr/local" --with-openssl --with-tpm2
+  - make -j$(nproc) install
+  - popd
+  - git clone --branch=v0.4.1 --depth=1 https://github.com/stefanberger/swtpm.git
+  - pushd swtpm
+  - autoreconf --install --force
+  - ./configure --prefix="$PWD/../installdir/usr/local"
+  - make -j$(nproc) install
+  - popd
 # OpenSSL 1.0.2 / 1.1.0
   - git clone --branch $OPENSSL_BRANCH --depth=1 https://github.com/openssl/openssl.git
   - pushd openssl
@@ -44,15 +61,6 @@ install:
   - make install
   - which openssl
   - popd
-# TPM Simulator
-  - wget --no-check-certificate https://download.01.org/tpm2/ibmtpm974.tar.gz
-    # we skip failing cert check and use the sha256sum instead
-  - sha256sum ibmtpm974.tar.gz | grep -q ^8e45d86129a0adb95fee4cee51f4b1e5b2d81ed3e55af875df53f98f39eb7ad7 || travis_terminate 1
-  - mkdir ibmtpm
-  - tar axf ibmtpm974.tar.gz -C ibmtpm
-  - make -C ibmtpm/src -j$(nproc)
-  - cp ibmtpm/src/tpm_server installdir/usr/local/bin
-  - which tpm_server
 # Autoconf archives
   - wget --no-check-certificate https://download.01.org/tpm2/autoconf-archive-2017.09.28.tar.xz
     # we skip failing cert check and use the sha256sum instead

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -16,7 +16,7 @@
 Integration tests also require:
 * expect
 * tpm2-tools 4.0 (or 4.X branch)
-* tpm_server
+* [swtpm](https://github.com/stefanberger/swtpm) or [tpm_server](https://sourceforge.net/projects/ibmswtpm2/)
 * realpath
 * ss
 

--- a/configure.ac
+++ b/configure.ac
@@ -180,9 +180,10 @@ AS_IF([test "x$enable_integration" = xyes && test "x$with_device_set" = xno],
        AC_CHECK_PROG([tpm2_startup], [tpm2_startup], [yes])
        AS_IF([test "x$tpm2_startup" != xyes],
              [AC_MSG_ERROR([Integration tests require the tpm2_startup executable])])
+       AC_CHECK_PROG([swtpm], [swtpm], [yes])
        AC_CHECK_PROG([tpm_server], [tpm_server], [yes])
-       AS_IF([test "x$tpm_server" != xyes],
-             [AC_MSG_ERROR([Integration tests require the tpm_server executable])])
+       AS_IF([test "x$swtpm" != xyes && test "x$tpm_server" != xyes],
+             [AC_MSG_ERROR([Integration tests require either the swtpm or the tpm_server executable])])
        AC_CHECK_PROG([realpath], [realpath], [yes])
        AS_IF([test "x$realpath" != xyes],
              [AC_MSG_ERROR([Integration tests require the realpath executable])])

--- a/test/sh_log_compiler.sh
+++ b/test/sh_log_compiler.sh
@@ -21,34 +21,50 @@ echo "Switching to temporary directory $tmp_dir"
 cd "$tmp_dir"
 
 if [ -z "$INTEGRATION_DEVICE" ]; then
-   # No device is passed so the TPM simulator will be used.
-   for attempt in $(seq 9 -1 0); do
-       tpm_server_port="$(shuf --input-range 1024-65534 --head-count 1)"
-       echo "Starting simulator on port $tpm_server_port"
-       tpm_server -port "$tpm_server_port" &
-       tpm_server_pid="$!"
-       sleep 1
+    # No device is passed so the TPM simulator will be used.
+    for simulator in 'swtpm' 'tpm_server'; do
+        simulator_binary="$(command -v "$simulator")" && break
+    done
+    if [ -z "$simulator_binary" ]; then
+        echo 'ERROR: No TPM simulator was found on PATH'
+        exit 99
+    fi
 
-       if ( ss --listening --tcp --ipv4 --processes | grep "$tpm_server_pid" | grep --quiet "$tpm_server_port" &&
-            ss --listening --tcp --ipv4 --processes | grep "$tpm_server_pid" | grep --quiet "$(( tpm_server_port + 1 ))" )
-       then
-           echo "Simulator with PID $tpm_server_pid started successfully"
-           break
-       else
-           echo "Failed to start simulator, the port might be in use"
-           kill "$tpm_server_pid"
+    for attempt in $(seq 9 -1 0); do
+        simulator_port="$(shuf --input-range 1024-65534 --head-count 1)"
+        echo "Starting simulator on port $simulator_port"
+        case "$simulator_binary" in
+            *swtpm) "$simulator_binary" socket --tpm2 --server port="$simulator_port" \
+                                               --ctrl type=tcp,port="$(( simulator_port + 1 ))" \
+                                               --flags not-need-init --tpmstate dir="$tmp_dir" &;;
+            *tpm_server) "$simulator_binary" -port "$simulator_port" &;;
+        esac
+        simulator_pid="$!"
+        sleep 1
 
-           if [ "$attempt" -eq 0 ]; then
-               echo 'ERROR: Reached maximum number of tries to start simulator, giving up'
-               exit 99
-           fi
-       fi
-   done
+        if ( ss --listening --tcp --ipv4 --processes | grep "$simulator_pid" | grep --quiet "$simulator_port" &&
+             ss --listening --tcp --ipv4 --processes | grep "$simulator_pid" | grep --quiet "$(( simulator_port + 1 ))" )
+        then
+            echo "Simulator with PID $simulator_pid started successfully"
+            break
+        else
+            echo "Failed to start simulator, the port might be in use"
+            kill "$simulator_pid"
 
-   export TPM2TSSENGINE_TCTI="libtss2-tcti-mssim.so:port=$tpm_server_port"
-   export TPM2TOOLS_TCTI="$TPM2TSSENGINE_TCTI"
+            if [ "$attempt" -eq 0 ]; then
+                echo 'ERROR: Reached maximum number of tries to start simulator, giving up'
+                exit 99
+            fi
+        fi
+    done
 
-   tpm2_startup --clear
+    case "$simulator_binary" in
+        *swtpm) export TPM2TSSENGINE_TCTI="swtpm:port=$simulator_port";;
+        *tpm_server) export TPM2TSSENGINE_TCTI="mssim:port=$simulator_port";;
+    esac
+    export TPM2TOOLS_TCTI="$TPM2TSSENGINE_TCTI"
+
+    tpm2_startup --clear
 else
     # A physical TPM will be used for the integration test.
     echo "Running the test with $INTEGRATION_DEVICE"
@@ -60,7 +76,7 @@ echo "Starting $test_script"
 "$test_script"
 test_status="$?"
 
-kill "$tpm_server_pid"
+kill "$simulator_pid"
 rm -rf "$tmp_dir"
 
 exit "$test_status"


### PR DESCRIPTION
This is a straightforward port of https://github.com/tpm2-software/tpm2-totp/pull/69 to add support for swtpm, since both project share almost the same codebase for the integration test framework.