### PR TITLE
tpm2tss-genkey: TPM key import

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -121,6 +121,8 @@ TESTS_SHELL = test/ecdsa.sh \
               test/rsasign.sh \
               test/failload.sh \
               test/failwrite.sh \
+              test/rsasign_importtpm.sh \
+              test/rsasign_importtpmparent.sh \
               test/rsasign_parent.sh \
               test/rsasign_parent_pass.sh \
               test/rsasign_persistent.sh \

--- a/include/tpm2-tss-engine.h
+++ b/include/tpm2-tss-engine.h
@@ -68,6 +68,11 @@ tpm2tss_tpm2data_read(const char *filename, TPM2_DATA **tpm2Datap);
 int
 tpm2tss_tpm2data_readtpm(uint32_t handle, TPM2_DATA **tpm2Datap);
 
+int
+tpm2tss_tpm2data_importtpm(const char *filenamepub, const char *filenametpm,
+                           TPM2_HANDLE parent, int emptyAuth,
+                           TPM2_DATA **tpm2Datap);
+
 EVP_PKEY *
 tpm2tss_rsa_makekey(TPM2_DATA *tpm2Data);
 

--- a/man/tpm2tss-genkey.1.md
+++ b/man/tpm2tss-genkey.1.md
@@ -1,6 +1,6 @@
 % tpm2tss-genkey(1) tpm2-tss-engine | General Commands Manual
 %
-% JUNE 2018
+% OCTOBER 2020
 
 # NAME
 **tpm2tss-genkey**(1) -- generate TPM keys for tpm2-tss-engine
@@ -31,6 +31,13 @@ key information. This file can then be loaded with OpenSSL using
 
   * `-c <curve>`, `--curve <curve>`:
     If alg ecdsa is chosen, the curve for ecc (default: nist_p256)
+
+  * `-u <file>`, `--public <file>`:
+    Public key (TPM2B_PUBLIC) to be imported. Requires `-r`.
+
+  * `-r <file>`, `--private <file>`:
+    The (encrypted) private key (TPM2B_PRIVATE) to be imported.
+    Requires `-u`.
 
   * `-e <exponent>`, `--exponent <exponent>`:
     If alg rsa is chosen, the exponent for rsa (default: 65537)

--- a/src/tpm2-tss-engine-common.c
+++ b/src/tpm2-tss-engine-common.c
@@ -592,3 +592,75 @@ init_tpm_key (ESYS_CONTEXT **esys_ctx, ESYS_TR *keyHandle, TPM2_DATA *tpm2Data)
     esys_ctx_free(esys_ctx);
     return r;
 }
+
+/** Deserialize a tpm key from disk
+ *
+ * Read a tpm key as marshaled TPM2B_PUBLIC and (encrypted) TPM2B_PRIVATE from
+ * disk and convert them into a TPM2_DATA representation
+ * @param filenamepub The filename to read the public portion from.
+ * @param filenametpm The filename to read the private portion from.
+ * @param parent Handle of the parent key.
+ * @param emptyAuth Whether the object does not require authentication.
+ * @param tpm2Datap The data after read.
+ * @retval 1 on success
+ * @retval 0 on failure
+ */
+int
+tpm2tss_tpm2data_importtpm(const char *filenamepub, const char *filenametpm,
+                           TPM2_HANDLE parent, int emptyAuth,
+                           TPM2_DATA **tpm2Datap)
+{
+    TSS2_RC r;
+    BIO *bio;
+    TPM2_DATA *tpm2data;
+    int filepub_size, filepriv_size;
+
+    uint8_t filepub[sizeof(TPM2B_PUBLIC)];
+    uint8_t filepriv[sizeof(TPM2B_PRIVATE)];
+
+    if ((bio = BIO_new_file(filenamepub, "r")) == NULL) {
+        ERR(tpm2tss_tpm2data_read, TPM2TSS_R_FILE_READ);
+        return 0;
+    }
+    filepub_size = BIO_read(bio, &filepub[0], sizeof(filepub));
+    BIO_free(bio);
+    if (filepub_size < 0) {
+        ERR(tpm2tss_tpm2data_read, TPM2TSS_R_FILE_READ);
+        return 0;
+    }
+
+    if ((bio = BIO_new_file(filenametpm, "r")) == NULL) {
+        ERR(tpm2tss_tpm2data_read, TPM2TSS_R_FILE_READ);
+        return 0;
+    }
+    filepriv_size = BIO_read(bio, &filepriv[0], sizeof(filepriv));
+    BIO_free(bio);
+    if (filepriv_size < 0) {
+        ERR(tpm2tss_tpm2data_read, TPM2TSS_R_FILE_READ);
+        return 0;
+    }
+
+    tpm2data = OPENSSL_malloc(sizeof(TPM2_DATA));
+    if (!tpm2data)
+        return 0;
+
+    memset(tpm2data, 0, sizeof(*tpm2data));
+    tpm2data->privatetype = KEY_TYPE_BLOB;
+    tpm2data->parent = parent;
+    tpm2data->emptyAuth = emptyAuth;
+
+    r = Tss2_MU_TPM2B_PUBLIC_Unmarshal(&filepub[0], filepub_size, NULL,
+                                       &tpm2data->pub);
+    ERRchktss(tpm2tss_tpm2data_read, r, goto error);
+
+    r = Tss2_MU_TPM2B_PRIVATE_Unmarshal(&filepriv[0], filepriv_size, NULL,
+                                        &tpm2data->priv);
+    ERRchktss(tpm2tss_tpm2data_read, r, goto error);
+
+    *tpm2Datap = tpm2data;
+    return 1;
+
+  error:
+    free(tpm2data);
+    return 0;
+}

--- a/test/rsasign_importtpm.sh
+++ b/test/rsasign_importtpm.sh
@@ -1,0 +1,39 @@
+#!/bin/bash
+
+set -eufx
+
+DIR=$(mktemp -d)
+TPM_RSA_PUBKEY=${DIR}/rsakey.pub
+TPM_RSA_KEY=${DIR}/rsakey
+PARENT_CTX=${DIR}/primary_owner_key.ctx
+
+echo -n "abcde12345abcde12345">${DIR}/mydata
+
+tpm2_startup -c || true
+
+# Create primary key as persistent handle
+tpm2_createprimary --hierarchy=o --hash-algorithm=sha256 --key-algorithm=ecc \
+                   --key-context=${PARENT_CTX} \
+                   --attributes="decrypt|fixedtpm|fixedparent|sensitivedataorigin|userwithauth|noda|restricted"
+tpm2_flushcontext --transient-object
+
+# Create an RSA key pair
+echo "Generating RSA key pair"
+tpm2_create --key-auth=abc --parent-context=${PARENT_CTX} \
+            --hash-algorithm=sha256 --key-algorithm=rsa \
+            --public=${TPM_RSA_PUBKEY} --private=${TPM_RSA_KEY} \
+            --attributes="sign|decrypt|fixedtpm|fixedparent|sensitivedataorigin|userwithauth|noda"
+tpm2_flushcontext --transient-object
+
+tpm2tss-genkey --public ${TPM_RSA_PUBKEY} --private ${TPM_RSA_KEY} --password abc ${DIR}/mykey
+
+echo "abc" | openssl rsa -engine tpm2tss -inform engine -in ${DIR}/mykey -pubout -outform pem -out ${DIR}/mykey.pub -passin stdin
+
+echo "abc" | openssl pkeyutl -engine tpm2tss -keyform engine -inkey ${DIR}/mykey -sign -in ${DIR}/mydata -out ${DIR}/mysig -passin stdin
+
+#this is a workaround because -verify allways exits 1
+R="$(openssl pkeyutl -pubin -inkey ${DIR}/mykey.pub -verify -in ${DIR}/mydata -sigfile ${DIR}/mysig || true)"
+if ! echo $R | grep "Signature Verified Successfully" >/dev/null; then
+    echo $R
+    exit 1
+fi

--- a/test/rsasign_importtpmparent.sh
+++ b/test/rsasign_importtpmparent.sh
@@ -1,0 +1,43 @@
+#!/bin/bash
+
+set -eufx
+
+DIR=$(mktemp -d)
+TPM_RSA_PUBKEY=${DIR}/rsakey.pub
+TPM_RSA_KEY=${DIR}/rsakey
+PARENT_CTX=${DIR}/primary_owner_key.ctx
+
+echo -n "abcde12345abcde12345">${DIR}/mydata
+
+tpm2_startup -c || true
+
+# Create primary key as persistent handle
+tpm2_createprimary --hierarchy=o --hash-algorithm=sha256 --key-algorithm=rsa \
+                   --key-context=${PARENT_CTX}
+tpm2_flushcontext --transient-object
+HANDLE=$(tpm2_evictcontrol --hierarchy=o --object-context=${PARENT_CTX} | cut -d ' ' -f 2 | head -n 1)
+tpm2_flushcontext --transient-object
+
+# Create an RSA key pair
+echo "Generating RSA key pair"
+tpm2_create --key-auth=abc --parent-context=${HANDLE} \
+            --hash-algorithm=sha256 --key-algorithm=rsa \
+            --public=${TPM_RSA_PUBKEY} --private=${TPM_RSA_KEY} \
+            --attributes="sign|decrypt|fixedtpm|fixedparent|sensitivedataorigin|userwithauth|noda"
+tpm2_flushcontext --transient-object
+
+tpm2tss-genkey --public ${TPM_RSA_PUBKEY} --private ${TPM_RSA_KEY} --password abc --parent ${HANDLE} ${DIR}/mykey
+
+echo "abc" | openssl rsa -engine tpm2tss -inform engine -in ${DIR}/mykey -pubout -outform pem -out ${DIR}/mykey.pub -passin stdin
+
+echo "abc" | openssl pkeyutl -engine tpm2tss -keyform engine -inkey ${DIR}/mykey -sign -in ${DIR}/mydata -out ${DIR}/mysig -passin stdin
+
+# Release persistent HANDLE
+tpm2_evictcontrol --hierarchy=o --object-context=${HANDLE}
+
+#this is a workaround because -verify allways exits 1
+R="$(openssl pkeyutl -pubin -inkey ${DIR}/mykey.pub -verify -in ${DIR}/mydata -sigfile ${DIR}/mysig || true)"
+if ! echo $R | grep "Signature Verified Successfully" >/dev/null; then
+    echo $R
+    exit 1
+fi


### PR DESCRIPTION
Introduce a possibility to import keys created e.g. with tpm2_create.
Consumes the public (-u) and private (-r) portion of the TPM key and
produces the 'TSS2 PRIVATE KEY' file.

Signed-off-by: Petr Gotthard <petr.gotthard@centrum.cz>
Co-authored-by: Andreas Fuchs <andreas.fuchs@sit.fraunhofer.de>
Co-authored-by: Takahide Higuchi <takahidehiguchi@gmail.com>