### PR TITLE
Enable Coverity Scan

### DIFF
--- a/.ci/coverity.run
+++ b/.ci/coverity.run
@@ -1,5 +1,108 @@
 #!/usr/bin/env bash
 # SPDX-License-Identifier: BSD-2
 
->&2 echo "ERROR: Automatic Coverity Scanning not set-up for this project"
-exit 1
+set -eo pipefail
+
+echo "PROJECT=$PROJECT"
+
+if [ -z "$COVERITY_SCAN_TOKEN" ]; then
+  echo "coverity.run invoked without COVERITY_SCAN_TOKEN set...exiting!"
+  exit 1
+fi
+
+if [ -z "$COVERITY_SUBMISSION_EMAIL" ]; then
+  echo "coverity.run invoked without COVERITY_SUBMISSION_EMAIL set...exiting!"
+  exit 1
+fi
+
+# Sanity check, this should only be executing on the coverity_scan branch
+if [[ "$REPO_BRANCH" != *coverity_scan ]]; then
+  echo "coverity.run invoked for non-coverity branch $REPO_BRANCH...exiting!"
+  exit 1
+fi
+
+if [[ "$CC" == clang* ]]; then
+  echo "Coverity scan branch detected, not running with clang...exiting!"
+  exit 1
+fi
+
+# branch is coverity_scan
+echo "Running coverity build"
+
+# ensure coverity_scan tool is available to the container
+# We cannot package these in the docker image, as we would be distributing their software
+# for folks not coupled to our COVERITY_SCAN_TOKEN.
+if [ ! -f "$(pwd)/cov-analysis/bin/cov-build" ]; then
+  curl --data-urlencode "project=$PROJECT" \
+       --data-urlencode "token=$COVERITY_SCAN_TOKEN" \
+       "https://scan.coverity.com/download/linux64" -o coverity_tool.tgz
+
+  stat coverity_tool.tgz
+
+  curl --data-urlencode "project=$PROJECT" \
+       --data-urlencode "token=$COVERITY_SCAN_TOKEN" \
+       --data-urlencode "md5=1" \
+       "https://scan.coverity.com/download/linux64" -o coverity_tool.md5
+
+  stat coverity_tool.md5
+  cat coverity_tool.md5
+  md5sum coverity_tool.tgz
+  echo "$(cat coverity_tool.md5)" coverity_tool.tgz | md5sum -c
+
+  echo "unpacking cov-analysis"
+  tar -xf coverity_tool.tgz
+  mv cov-analysis-* cov-analysis
+fi
+
+export PATH=$PATH:$(pwd)/cov-analysis/bin
+
+echo "Which cov-build: $(which cov-build)"
+
+# get the deps to build with
+$DOCKER_BUILD_DIR/.ci/get_deps.sh "$(dirname $DOCKER_BUILD_DIR)"
+
+pushd "$DOCKER_BUILD_DIR"
+
+echo "Performing build with Coverity Scan"
+rm -rf cov-int
+./bootstrap && ./configure --enable-debug && make clean
+cov-build --dir $DOCKER_BUILD_DIR/cov-int make -j $(nproc)
+
+echo "Collecting Coverity data for submission"
+rm -fr README
+AUTHOR="$(git log -1 $HEAD --pretty="%aN")"
+AUTHOR_EMAIL="$(git log -1 $HEAD --pretty="%aE")"
+VERSION="$(git rev-parse HEAD)"
+echo "Name: $AUTHOR" >> README
+echo "Email: $AUTHOR_EMAIL" >> README
+echo "Project: tpm2-pkcs11" >> README
+echo "Build-Version: $VERSION" >> README
+echo "Description: $REPO_SLUG $REPO_BRANCH" >> README
+echo "Submitted-by: tpm2-pkcs11 CI" >> README
+echo "---README---"
+cat README
+echo "---EOF---"
+
+rm -f tpm2-pkcs11-scan.tgz
+tar -czf tpm2-pkcs11-scan.tgz README cov-int
+
+rm -rf README cov-int
+
+# upload the results
+echo "Testing for scan results..."
+scan_file=$(stat --printf='%n' tpm2-*-scan.tgz)
+
+echo "Submitting data to Coverity"
+curl --form token="$COVERITY_SCAN_TOKEN" \
+  --form email="$COVERITY_SUBMISSION_EMAIL" \
+  --form project="$PROJECT" \
+  --form file=@"$scan_file" \
+  --form version="$VERSION" \
+  --form description="$REPO_SLUG $REPO_BRANCH" \
+  "https://scan.coverity.com/builds?project=$PROJECT"
+
+rm -rf tpm2-*-scan.tgz
+
+popd
+
+exit 0

--- a/.github/workflows/coverity.yml
+++ b/.github/workflows/coverity.yml
@@ -1,0 +1,21 @@
+name: Coverity Scan
+on: push
+jobs:
+  coverity-scan:
+    runs-on: ubuntu-latest
+    if: contains(github.ref, 'coverity_scan')
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v2
+      - name: Launch Container
+        env:
+          ENABLE_COVERITY: true
+          TPM2TSS_BRANCH: "3.0.x"
+          TPM2TOOLS_BRANCH: "4.0"
+          REPO_BRANCH: ${{ github.ref }}
+          REPO_SLUG: ${{ github.repository }}
+          DOCKER_IMAGE: ubuntu-18.04
+          CC: gcc
+          COVERITY_SCAN_TOKEN: ${{ secrets.COVERITY_SCAN_TOKEN }}
+          COVERITY_SUBMISSION_EMAIL: william.c.roberts@intel.com
+        run: ./.ci/ci-runner.sh

--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 [![Linux Build Status](https://travis-ci.org/tpm2-software/tpm2-tss-engine.svg?branch=master)](https://travis-ci.org/tpm2-software/tpm2-tss-engine)
 [![Code Coverage](https://codecov.io/gh/tpm2-software/tpm2-tss-engine/branch/master/graph/badge.svg)](https://codecov.io/gh/tpm2-software/tpm2-tss-engine)
 [![Language grade: C/C++](https://img.shields.io/lgtm/grade/cpp/g/tpm2-software/tpm2-tss-engine.svg?logo=lgtm&logoWidth=18)](https://lgtm.com/projects/g/tpm2-software/tpm2-tss-engine/context:cpp)
+[![Coverity Scan](https://img.shields.io/coverity/scan/22247.svg)](https://scan.coverity.com/projects/tpm2-tss-engine)
+
 
 # Overview
 The tpm2-tss-engine project implements a cryptographic engine for


### PR DESCRIPTION
Enable a Github Action to build and push to the Open Source Coverity server when a push is conducted to the coverity_scan branch. 

A test was conducted from the coverity_scan branch and can be seen here:
  - https://github.com/tpm2-software/tpm2-tss-engine/runs/1578302824?check_suite_focus=true

coverity_scan branch is missing the README.md changes to add the coverity badging, but is otherwise identical.