### PR TITLE
Add basic implementation for ECDH.

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -127,6 +127,9 @@ TESTS_SHELL = test/ecdsa.sh \
               test/rsasign_persistent_emptyauth.sh \
               test/sserver.sh \
               test/sclient.sh
+if HAVE_OPENSSL_ECDH
+TESTS_SHELL += test/ecdh.sh
+endif
 EXTRA_DIST += $(TESTS_SHELL)
 TEST_EXTENSIONS = .sh
 SH_LOG_COMPILER = $(srcdir)/test/sh_log_compiler.sh

--- a/configure.ac
+++ b/configure.ac
@@ -117,6 +117,9 @@ PKG_CHECK_MODULES([CRYPTO], [libcrypto >= 1.0.2g],
 PKG_CHECK_MODULES([TSS2_ESYS], [tss2-esys >= 2.3])
 PKG_CHECK_MODULES([TSS2_MU], [tss2-mu])
 PKG_CHECK_MODULES([TSS2_TCTILDR], [tss2-tctildr])
+AC_CHECK_LIB([crypto], EC_KEY_METHOD_set_compute_key,
+      [AM_CONDITIONAL([HAVE_OPENSSL_ECDH], true)],
+      [AM_CONDITIONAL([HAVE_OPENSSL_ECDH], false)])
 
 AC_PATH_PROG([PANDOC], [pandoc])
 AS_IF([test -z "$PANDOC"],

--- a/include/tpm2-tss-engine.h
+++ b/include/tpm2-tss-engine.h
@@ -83,7 +83,11 @@ tpm2tss_ecc_genkey(EC_KEY *key, TPMI_ECC_CURVE curve, const char *password,
                    TPM2_HANDLE parentHandle);
 
 TPM2_DATA *
+#if OPENSSL_VERSION_NUMBER < 0x10100000
 tpm2tss_ecc_getappdata(EC_KEY *key);
+#else /* OPENSSL_VERSION_NUMBER < 0x10100000 */
+tpm2tss_ecc_getappdata(const EC_KEY *key);
+#endif /* OPENSSL_VERSION_NUMBER < 0x10100000 */
 
 int
 tpm2tss_ecc_setappdata(EC_KEY *key, TPM2_DATA *data);

--- a/man/tpm2tss_ecc_getappdata.3.md
+++ b/man/tpm2tss_ecc_getappdata.3.md
@@ -9,7 +9,7 @@
 
 **#include <tpm2tss.h>**
 
-**TPM2_DATA * tpm2tss_ecc_getappdata(EC_KEY *key);**
+**TPM2_DATA * tpm2tss_ecc_getappdata(const EC_KEY *key);**
 
 **int tpm2tss_ecc_setappdata(EC_KEY *key, TPM2_DATA *data);**
 

--- a/src/tpm2-tss-engine-ecc.c
+++ b/src/tpm2-tss-engine-ecc.c
@@ -414,7 +414,11 @@ tpm2tss_ecc_makekey(TPM2_DATA *tpm2Data)
  * @retval NULL on failure.
  */
 TPM2_DATA *
+#if OPENSSL_VERSION_NUMBER < 0x10100000
 tpm2tss_ecc_getappdata(EC_KEY *key)
+#else /* OPENSSL_VERSION_NUMBER < 0x10100000 */
+tpm2tss_ecc_getappdata(const EC_KEY *key)
+#endif /* OPENSSL_VERSION_NUMBER < 0x10100000 */
 {
     if (ec_key_app_data == -1) {
         DBG("Module uninitialized\n");

--- a/src/tpm2-tss-engine-err.h
+++ b/src/tpm2-tss-engine-err.h
@@ -86,6 +86,8 @@ void ERR_error(int function, int reason, const char *file, int line);
 #define TPM2TSS_F_populate_ecc          121
 #define TPM2TSS_F_tpm2tss_ecc_genkey    122
 #define TPM2TSS_F_tpm2tss_ecc_makekey      123
+#define TPM2TSS_F_ecdh_compute_key      124
+
 /* tpm2-tss-engine-rand.c */
 #define TPM2TSS_F_rand_bytes    130
 /* tpm2-tss-engine-rsa.c */

--- a/test/ecdh.sh
+++ b/test/ecdh.sh
@@ -1,0 +1,62 @@
+#!/bin/bash
+
+set -euf
+
+# Create a primary key pair
+echo "Generating primary key"
+PARENT_CTX=primary_owner_key.ctx
+tpm2_createprimary --hierarchy=o \
+                   --key-algorithm=ecc \
+                   --hash-algorithm=sha256 \
+                   --key-context=${PARENT_CTX}
+
+# Create an ECDH key pair
+echo "Generating ECDH key pair"
+ECDH_TPM_PUBKEY=ecdhtpm.pub
+ECDH_TPM_KEY=ecdhtpm
+tpm2_create --key-auth=abc \
+            --parent-context=${PARENT_CTX} \
+            --key-algorithm=ecc256:ecdh-sha256 \
+            --public=${ECDH_TPM_PUBKEY} \
+            --private=${ECDH_TPM_KEY} \
+            --attributes fixedparent\|fixedtpm\|decrypt\|sensitivedataorigin\|userwithauth\|noda
+tpm2_flushcontext --transient-object
+
+# Load key to persistent handle
+ECDH_CTX=ecdhkey.ctx
+tpm2_load --parent-context=${PARENT_CTX} \
+          --public=${ECDH_TPM_PUBKEY} \
+          --private=${ECDH_TPM_KEY} \
+          --key-context=${ECDH_CTX}
+tpm2_flushcontext --transient-object
+
+HANDLE=$(tpm2_evictcontrol --hierarchy=o --object-context=${ECDH_CTX} | cut -d ' ' -f 2 | head -n 1)
+tpm2_flushcontext --transient-object
+
+# Get public key of handle
+ECDH_TPM_PUBKEY_PEM=ecdhtpm.pem
+tpm2_readpublic --object-context=${HANDLE} --output=${ECDH_TPM_PUBKEY_PEM} --format=pem
+
+# Generate peer key pair
+ECDH_PEER_PUBKEY=echdpeer.pub
+ECDH_PEER_KEY=ecdhpeer
+openssl ecparam -name prime256v1 -genkey -noout -out ${ECDH_PEER_KEY}
+openssl ec -in ${ECDH_PEER_KEY} -pubout -out ${ECDH_PEER_PUBKEY}
+
+# Perform ECDH using the TPM key pair as the private key and the peer key pair as the public key
+SECRET0=$(echo "abc" | openssl pkeyutl -derive -engine tpm2tss -keyform engine -inkey ${HANDLE} -peerkey ${ECDH_PEER_PUBKEY} -peerform pem -passin stdin | base64)
+echo -e "TPM(prv) <-> PEER(pub): ${SECRET0}"
+
+# Perform ECDH with the peer key pair as the private key and the TPM key pair as the public key
+SECRET1=$(openssl pkeyutl -derive -inkey ${ECDH_PEER_KEY} -peerkey ${ECDH_TPM_PUBKEY_PEM} -peerform pem | base64)
+echo -e "TPM(pub) <-> PEER(prv): ${SECRET1}"
+
+# Release persistent HANDLE and remove files
+tpm2_evictcontrol --object-context=${HANDLE}
+rm ${ECDH_PEER_KEY} ${ECDH_PEER_PUBKEY} ${ECDH_TPM_PUBKEY} ${ECDH_TPM_KEY} ${ECDH_TPM_PUBKEY_PEM} ${ECDH_CTX}
+
+# Ensure tpm and peer generated secrets are the same
+if [ "${SECRET0}" != "${SECRET1}" ]; then
+    echo "secrets don't match"
+    exit 1
+fi


### PR DESCRIPTION
Fixes #206.

### Add support for ECDH

The implementation uses TPM2_ECDH_ZGen as provided by tss2-esys ([Esys_ECDH_ZGen()](https://github.com/tpm2-software/tpm2-tss/blob/ac2011c715f8611c44d073efc059fad4d3e7ed77/src/tss2-esys/api/Esys_ECDH_ZGen.c#L62)). A persistent handle value referencing the TPM private key is specified as the key context. Like other engine function implementations, a password session (ESYS_TR_PASSWORD) is used for authorization of the session handle. The public point is expected in uncompressed form.

**ECDH Validation**
Use newly added integration test under tests/ecdh.sh.