### PR TITLE
lgtm: update build script with acl

### DIFF
--- a/.lgtm.yml
+++ b/.lgtm.yml
@@ -6,6 +6,7 @@ extraction:
       - libcurl4-openssl-dev
       - libjson-c-dev
       - libssl-dev
+      - acl
     after_prepare:
     - cd "$LGTM_WORKSPACE"
     - mkdir installdir


### PR DESCRIPTION
Fixes:
[2021-04-26 19:38:54] [build-stdout] checking for chmod... yes
[2021-04-26 19:38:54] [build-stdout] checking for mkdir... yes
[2021-04-26 19:38:54] [build-stdout] checking for setfacl... no
[2021-04-26 19:38:54] [build-stderr] configure: error: Missing required program 'setfacl': ensure it is installed and on PATH.
[2021-04-26 19:38:54] [ERROR] Spawned process exited abnormally (code 1; tried to run: [/opt/work/lgtm-workspace/lgtm/extract.sh])
A fatal error occurred: Exit status 1 from command: [/opt/work/lgtm-workspace/lgtm/extract.sh]

Signed-off-by: William Roberts <william.c.roberts@intel.com>