### PR TITLE
build: only use -Werror for non-release builds

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -57,6 +57,7 @@ AM_INIT_AUTOMAKE([foreign subdir-objects -Wall -Wno-portability])
 m4_ifdef([AM_SILENT_RULES], [AM_SILENT_RULES([yes])]) 
 AM_MAINTAINER_MODE([enable])
 
+AX_IS_RELEASE([dash-version])
 AX_CHECK_ENABLE_DEBUG([info])
 
 AC_PROG_CC
@@ -88,7 +89,7 @@ AS_IF([test "x$enable_defaultflags" = "xyes"],
       AX_ADD_COMPILER_FLAG([-Wall])
       AX_ADD_COMPILER_FLAG([-Wextra])
       AX_ADD_COMPILER_FLAG([-Wformat-security])
-      AX_ADD_COMPILER_FLAG([-Werror])
+      AS_IF([test "x$ax_is_release" = "xno"], [AX_ADD_COMPILER_FLAG([-Werror])])
       AX_ADD_COMPILER_FLAG([-fstack-protector-all])
       AX_ADD_COMPILER_FLAG([-fpic])
       AX_ADD_COMPILER_FLAG([-fPIC])


### PR DESCRIPTION
While we want to catch any compiler warnings during development, a release build should never fail due to e.g. stricter static checks introduced by new compiler versions. Therefore make `-Werror` conditional on `AX_IS_RELEASE`, like e.g. [tpm2-tss does](https://github.com/tpm2-software/tpm2-tss/blob/2bae50a3551cd8b0123ef609ea973678339df5ae/configure.ac#L435-L436).

tpm2-tss-engine has no issues with the recently released GCC 11 as far as I am aware, but it never hurts to be proactive.