### PR TITLE
ci: install acl for LGTM

### DIFF
--- a/.lgtm.yml
+++ b/.lgtm.yml
@@ -6,6 +6,7 @@ extraction:
       - libcurl4-openssl-dev
       - libjson-c-dev
       - libssl-dev
+      - acl
     after_prepare:
     - cd "$LGTM_WORKSPACE"
     - mkdir installdir


### PR DESCRIPTION
This is required since upstream tpm2-tss commit https://github.com/tpm2-software/tpm2-tss/commit/9d42f4dbde6a94724e95d57c333cda7711dda57c ("configure: add checks for all tools used by make install").