### PR TITLE
Fix unused parameter error in ERR_error with OpenSSL 3.0

### DIFF
--- a/src/tpm2-tss-engine-err.c
+++ b/src/tpm2-tss-engine-err.c
@@ -160,6 +160,9 @@ ERR_unload_TPM2TSS_strings(void)
 void
 ERR_error(int function, int reason, const char *file, int line)
 {
+    (void)(function);
+    (void)(file);
+    (void)(line);
     if (TPM2TSS_lib_error_code == 0)
         TPM2TSS_lib_error_code = ERR_get_next_error_library();
     ERR_PUT_error(TPM2TSS_lib_error_code, function, reason, file, line);


### PR DESCRIPTION
The `ERR_PUT_error` in OpenSSL 3.0 is macro that doesn't always use all its parameters, so the compiler may produce the 'unused parameter' error. This PR makes the compiler happy again. I believe it is harmless for older OpenSSLs too.

Note: The openssl 3.0.0 must be built in a "backwards compatibility mode" to built ENGINEs.