### PR TITLE
lgtm: fix build not finding ESYS

### DIFF
--- a/.lgtm.yml
+++ b/.lgtm.yml
@@ -10,9 +10,8 @@ extraction:
     after_prepare:
     - cd "$LGTM_WORKSPACE"
     - mkdir installdir
-    - wget https://github.com/tpm2-software/tpm2-tss/archive/master.tar.gz
-    - tar xf master.tar.gz
-    - cd tpm2-tss-master
+    - git clone https://github.com/tpm2-software/tpm2-tss.git
+    - cd tpm2-tss
     - ./bootstrap
     - ./configure --prefix="$LGTM_WORKSPACE/installdir/usr" --disable-doxygen-doc
     - make install


### PR DESCRIPTION
Fixes:
[2021-09-08 11:00:10] [build-stdout] checking for TSS2_ESYS... no
[2021-09-08 11:00:10] [build-stdout] configure: error: Package requirements (tss2-esys >= 2.3) were not met:
[2021-09-08 11:00:10] [build-stdout] Package dependency requirement 'tss2-esys >= 2.3' could not be satisfied.
[2021-09-08 11:00:10] [build-stdout] Package 'tss2-esys' has version '', required version is '>= 2.3'
[2021-09-08 11:00:10] [build-stdout] Consider adjusting the PKG_CONFIG_PATH environment variable if you
[2021-09-08 11:00:10] [build-stdout] installed software in a non-standard prefix.
[2021-09-08 11:00:10] [build-stdout] Alternatively, you may set the environment variables TSS2_ESYS_CFLAGS
[2021-09-08 11:00:10] [build-stdout] and TSS2_ESYS_LIBS to avoid the need to call pkg-config.

The root cause is that tpm2-tss now gets its version from git describe,
so you have to clone it.

Signed-off-by: William Roberts <william.c.roberts@intel.com>