### PR TITLE
tpm2-tss-engine: memcpy hardening patches

### DIFF
--- a/src/tpm2-tss-engine-ecc.c
+++ b/src/tpm2-tss-engine-ecc.c
@@ -131,15 +131,28 @@ init_tpm_public_point(TPM2B_ECC_POINT *point, const EC_POINT *ec_point,
                         const EC_GROUP *ec_group)
 {
     unsigned char buffer[1 + sizeof(point->point.x.buffer)
-                           + sizeof(point->point.y.buffer)];
+                           + sizeof(point->point.y.buffer)] = {0};
+
     BN_CTX *ctx = BN_CTX_new();
     if (!ctx)
         return 0;
 
     BN_CTX_start(ctx);
-    size_t len = EC_POINT_point2oct(ec_group, ec_point,
+
+    size_t len = 0;
+
+    // first, check for actual buffer size required
+    if ((len = EC_POINT_point2oct(ec_group, ec_point, POINT_CONVERSION_UNCOMPRESSED, NULL, 0, ctx)) <= sizeof(buffer)) {
+        len = EC_POINT_point2oct(ec_group, ec_point,
                     POINT_CONVERSION_UNCOMPRESSED, buffer, sizeof(buffer), ctx);
+    }
+
+    BN_CTX_end(ctx);
     BN_CTX_free(ctx);
+
+    if (len == 0 || len > sizeof(buffer))
+        return 0;
+
     len = (len - 1) / 2;
 
     point->point.x.size = len;
@@ -309,7 +322,7 @@ ecdsa_sign(const unsigned char *dgst, int dgst_len, const BIGNUM *inv,
         ERR(ecdsa_sign, TPM2TSS_R_DIGEST_TOO_LARGE);
         goto error;
     }
-    memcpy(&digest.buffer[0], dgst, dgst_len);
+    memcpy(&digest.buffer[0], dgst, digest.size);
 
     r = init_tpm_key(&esys_ctx, &keyHandle, tpm2Data);
     ERRchktss(ecdsa_sign, r, goto error);
@@ -596,7 +609,7 @@ tpm2tss_ecc_genkey(EC_KEY *key, TPMI_ECC_CURVE curve, const char *password,
 
     if (password) {
         DBG("Setting a password for the created key.\n");
-        if (strlen(password) > sizeof(tpm2Data->userauth.buffer) - 1) {
+        if (strlen(password) > sizeof(tpm2Data->userauth.buffer) - 1 || strlen(password) > sizeof(inSensitive.sensitive.userAuth.buffer) - 1) {
             goto error;
         }
         tpm2Data->userauth.size = strlen(password);

--- a/src/tpm2-tss-engine-rsa.c
+++ b/src/tpm2-tss-engine-rsa.c
@@ -169,6 +169,10 @@ rsa_priv_enc(int flen, const unsigned char *from, unsigned char *to, RSA *rsa,
     DBGBUF(&sig->buffer[0], sig->size);
 
     ret = sig->size;
+    if (ret > RSA_size(rsa) || ret <= 0) {
+        ERR(rsa_priv_enc, TPM2TSS_R_DIGEST_TOO_LARGE);
+        goto error;
+    }
     memcpy(to, &sig->buffer[0], ret);
 
     goto out;
@@ -226,7 +230,7 @@ rsa_priv_dec(int flen, const unsigned char *from, unsigned char *to, RSA * rsa,
     TPMT_RSA_DECRYPT inScheme;
 
     TPM2B_PUBLIC_KEY_RSA cipher = { .size = flen };
-    if (flen > (int)sizeof(cipher.buffer)) {
+    if (flen > (int)sizeof(cipher.buffer) || flen < 0) {
         ERR(rsa_priv_dec, TPM2TSS_R_DIGEST_TOO_LARGE);
         goto error;
     }
@@ -257,6 +261,10 @@ rsa_priv_dec(int flen, const unsigned char *from, unsigned char *to, RSA * rsa,
     DBGBUF(&message->buffer[0], message->size);
 
     flen = message->size;
+    if (flen > RSA_size(rsa) || flen <= 0) {
+        ERR(rsa_priv_dec, TPM2TSS_R_DIGEST_TOO_LARGE);
+        goto error;
+    }
     memcpy(to, &message->buffer[0], flen);
 
     goto out;


### PR DESCRIPTION
Adding hardening patches to avoid potential memory corruptions if users pass edgy parameters or TPMs
return invalid sizes for whatever reason. Please thoroughly test before applying.

Signed-off-by: Sebastian <sebastian.krahmer@gmail.com>