### PR TITLE
Add ability to digest & sign with restricted ECC key

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -134,7 +134,8 @@ if HAVE_OPENSSL_ECDH
 TESTS_SHELL += test/ecdh.sh
 endif
 if HAVE_OPENSSL_DIGEST_SIGN
-TESTS_SHELL += test/ecdsa-restricted.sh
+TESTS_SHELL += test/ecdsa-restricted.sh \
+               test/rsasign_restricted.sh
 endif
 EXTRA_DIST += $(TESTS_SHELL) test/neg-handle.pem
 TEST_EXTENSIONS = .sh

--- a/Makefile.am
+++ b/Makefile.am
@@ -69,6 +69,7 @@ include_HEADERS = include/tpm2-tss-engine.h
 libtpm2tss_la_SOURCES = src/tpm2-tss-engine.c \
                         src/tpm2-tss-engine-common.c \
                         src/tpm2-tss-engine-common.h \
+                        src/tpm2-tss-engine-digest-sign.c \
                         src/tpm2-tss-engine-err.c \
                         src/tpm2-tss-engine-err.h \
                         src/tpm2-tss-engine-ecc.c \
@@ -131,6 +132,9 @@ TESTS_SHELL = test/ecdsa.sh \
               test/sclient.sh
 if HAVE_OPENSSL_ECDH
 TESTS_SHELL += test/ecdh.sh
+endif
+if HAVE_OPENSSL_DIGEST_SIGN
+TESTS_SHELL += test/ecdsa-restricted.sh
 endif
 EXTRA_DIST += $(TESTS_SHELL) test/neg-handle.pem
 TEST_EXTENSIONS = .sh

--- a/README.md
+++ b/README.md
@@ -122,6 +122,17 @@ $ tpm2tss-genkey -a rsa rsa.tss
 $ openssl req -new -x509 -engine tpm2tss -key rsa.tss  -keyform engine -out rsa.crt
 ```
 
+## Signing using restricted key
+Signing using a restricted ECDSA key is possible with the caveat that
+the TPM must be used for the digest, so higher-level digest & sign
+operations must be used instead, e.g.:
+```
+$ openssl dgst -engine tpm2tss -keyform engine -sha256 -sign ${HANDLE} -out mysig mydata.txt
+```
+Where `${HANDLE}` is the TPM persistent handle ID for the restricted
+key created by an external tool (since tpm2tss-genkey doesn't support
+creating restricted keys).
+
 # TLS and s_server
 This engine can be used in all places where OpenSSL is used to create a TLS
 secure channel connection. You have can specify the command

--- a/configure.ac
+++ b/configure.ac
@@ -119,6 +119,12 @@ PKG_CHECK_MODULES([TSS2_TCTILDR], [tss2-tctildr])
 AC_CHECK_LIB([crypto], EC_KEY_METHOD_set_compute_key,
       [AM_CONDITIONAL([HAVE_OPENSSL_ECDH], true)],
       [AM_CONDITIONAL([HAVE_OPENSSL_ECDH], false)])
+AC_CHECK_LIB([crypto], EVP_PKEY_meth_set_digest_custom,
+      [AM_CONDITIONAL([HAVE_OPENSSL_DIGEST_SIGN], true)],
+      [AM_CONDITIONAL([HAVE_OPENSSL_DIGEST_SIGN], false)])
+AS_IF([test "x$ac_cv_lib_crypto_EVP_PKEY_meth_set_digest_custom" = xyes],
+      [AC_DEFINE([HAVE_OPENSSL_DIGEST_SIGN], [1],
+                 Have required functionality from OpenSSL to support digest and sign)])
 
 AC_PATH_PROG([PANDOC], [pandoc])
 AS_IF([test -z "$PANDOC"],

--- a/src/tpm2-tss-engine-digest-sign.c
+++ b/src/tpm2-tss-engine-digest-sign.c
@@ -1,0 +1,312 @@
+/*******************************************************************************
+ * Copyright 2021, Graphiant, Inc.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ * this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of tpm2-tss-engine nor the names of its contributors
+ * may be used to endorse or promote products derived from this software
+ * without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ ******************************************************************************/
+
+#include <string.h>
+
+#include <openssl/evp.h>
+
+#include <tss2/tss2_esys.h>
+
+#include "tpm2-tss-engine-common.h"
+
+#ifndef TPM2_TSS_ENGINE_HAVE_C11_ATOMICS
+/* fall back to using GCC/clang atomic builtins */
+# define atomic_fetch_add(PTR, VAL) \
+    __atomic_fetch_add((PTR), (VAL), __ATOMIC_SEQ_CST)
+#define atomic_fetch_sub(PTR, VAL) \
+    __atomic_fetch_sub ((PTR), (VAL), __ATOMIC_SEQ_CST)
+#endif /* TPM2_TSS_ENGINE_HAVE_C11_ATOMICS */
+
+/**
+ * Initialise a digest operation for digest and sign.
+ *
+ * @param ctx OpenSSL message digest context
+ * @param data Digest and sign data
+ * @retval 1 on success
+ * @retval 0 on failure
+ */
+static int
+digest_init(EVP_MD_CTX *ctx, TPM2_SIG_DATA *data)
+{
+    TPM2B_AUTH null_auth = { .size = 0 };
+    const EVP_MD *md;
+    TSS2_RC r;
+
+    md = EVP_MD_CTX_md(ctx);
+    if (!md) {
+        ERR(digest_init, TPM2TSS_R_GENERAL_FAILURE);
+        return 0;
+    }
+
+    switch (EVP_MD_type(md)) {
+    case NID_sha1:
+        data->hash_alg = TPM2_ALG_SHA1;
+        break;
+    case NID_sha256:
+        data->hash_alg = TPM2_ALG_SHA256;
+        break;
+    case NID_sha384:
+        data->hash_alg = TPM2_ALG_SHA384;
+        break;
+    case NID_sha512:
+        data->hash_alg = TPM2_ALG_SHA512;
+        break;
+    default:
+        ERR(digest_init, TPM2TSS_R_UNKNOWN_ALG);
+        return 0;
+    }
+
+    r = Esys_HashSequenceStart(data->key->esys_ctx, ESYS_TR_NONE,
+                               ESYS_TR_NONE, ESYS_TR_NONE, &null_auth,
+                               data->hash_alg, &data->seq_handle);
+    ERRchktss(digest_init, r, return 0);
+
+    return 1;
+}
+
+/**
+ * Update a digest with more data
+ *
+ * @param ctx OpenSSL message digest context
+ * @param data Data to add to digest
+ * @param count Length of data to add
+ * @retval 1 on success
+ * @retval 0 on failure
+ */
+int
+digest_update(EVP_MD_CTX *ctx, const void *data, size_t count)
+{
+    EVP_PKEY_CTX *pctx = EVP_MD_CTX_pkey_ctx(ctx);
+    TPM2_SIG_DATA *sig_data = EVP_PKEY_CTX_get_app_data(pctx);
+    TSS2_RC r;
+
+    DBG("digest_update %p %p\n", pctx, ctx);
+
+    TPM2B_MAX_BUFFER digest_data = { .size = count };
+    if (count > sizeof(digest_data.buffer)) {
+        ERR(digest_update, TPM2TSS_R_DIGEST_TOO_LARGE);
+        return 0;
+    }
+    memcpy(&digest_data.buffer[0], data, count);
+
+    r = Esys_SequenceUpdate(sig_data->key->esys_ctx, sig_data->seq_handle,
+                            ESYS_TR_PASSWORD, ESYS_TR_NONE,
+                            ESYS_TR_NONE, &digest_data);
+    ERRchktss(digest_update, r, return 0);
+
+    return 1;
+}
+
+/**
+ * Finish a digest operation for digest and sign
+ *
+ * @param data Digest and sign data
+ * @param digest Digest calculated by TPM
+ * @param validation Validation ticket for the digest calculated by TPM
+ * @retval 1 on success
+ * @retval 0 on failure
+ */
+int
+digest_finish(TPM2_SIG_DATA *data, TPM2B_DIGEST **digest,
+              TPMT_TK_HASHCHECK **validation)
+{
+    TSS2_RC r;
+
+    r = Esys_SequenceComplete(data->key->esys_ctx, data->seq_handle,
+                              ESYS_TR_PASSWORD, ESYS_TR_NONE,
+                              ESYS_TR_NONE, NULL, ESYS_TR_RH_OWNER,
+                              digest, validation);
+    ERRchktss(digest_finish, r, return 0);
+
+    /* Esys_SequenceComplete consumes the handle */
+    data->seq_handle = ESYS_TR_NONE;
+
+    return 1;
+}
+
+/**
+ * Initialise a digest and sign operation
+ *
+ * @param ctx OpenSSL pkey context
+ * @param mctx OpenSSL message digest context
+ * @param tpm2data TPM data for the key to use
+ * @param sig_size Size of the signature data
+ * @retval 1 on success
+ * @retval 0 on failure
+ */
+int
+digest_sign_init(EVP_PKEY_CTX *ctx, EVP_MD_CTX *mctx, TPM2_DATA *tpm2data,
+                 size_t sig_size)
+{
+    TSS2_RC r;
+
+    if (!tpm2data)
+        /* non-TPM key - nothing to do */
+        return 1;
+
+    TPM2_SIG_DATA *data = calloc(sizeof(*data), 1);
+    if (!data) {
+        ERR(digest_sign_init, ERR_R_MALLOC_FAILURE);
+        return 0;
+    }
+
+    data->seq_handle = ESYS_TR_NONE;
+    data->sig_size = sig_size;
+
+    data->key = calloc(sizeof(*data->key), 1);
+    if (!data->key) {
+        ERR(digest_sign_init, ERR_R_MALLOC_FAILURE);
+        goto error;
+    }
+
+    data->key->refcount = 1;
+
+    r = init_tpm_key(&data->key->esys_ctx, &data->key->key_handle, tpm2data);
+    ERRchktss(digest_sign_init, r, goto error);
+    data->key->privatetype = tpm2data->privatetype;
+
+    EVP_PKEY_CTX_set_app_data(ctx, data);
+    /*
+     * Override the update function so that the TPM performs the
+     * digest, which is required for restricted keys - the TPM will
+     * reject a null validation ticket in this case for the signing
+     * operation.
+     */
+    EVP_MD_CTX_set_update_fn(mctx, digest_update);
+
+    if (!digest_init(mctx, data))
+        goto error;
+
+    return 1;
+
+ error:
+    if (data->key) {
+        if (data->key->key_handle != ESYS_TR_NONE) {
+            if (data->key->privatetype == KEY_TYPE_HANDLE) {
+                Esys_TR_Close(data->key->esys_ctx, &data->key->key_handle);
+            } else {
+                Esys_FlushContext(data->key->esys_ctx, data->key->key_handle);
+            }
+        }
+        if (data->key->esys_ctx)
+            esys_ctx_free(&data->key->esys_ctx);
+        free(data->key);
+    }
+    free(data);
+    return 0;
+}
+
+/**
+ * Copy digest and sign context
+ *
+ * @param dst Destination OpenSSL pkey context
+ * @param src Source OpenSSL pkey context
+ * @retval 1 on success
+ * @retval 0 on failure
+ */
+int
+digest_sign_copy(EVP_PKEY_CTX *dst, EVP_PKEY_CTX *src)
+{
+    TPM2_SIG_DATA *src_sig_data = EVP_PKEY_CTX_get_app_data(src);
+    TPMS_CONTEXT *context = NULL;
+    TPM2_SIG_DATA *dst_sig_data = NULL;
+    TSS2_RC r;
+
+    if (src_sig_data) {
+        dst_sig_data = calloc(sizeof(*dst_sig_data), 1);
+        if (!dst_sig_data) {
+            ERR(digest_sign_copy, ERR_R_MALLOC_FAILURE);
+            return 0;
+        }
+
+        dst_sig_data->hash_alg = src_sig_data->hash_alg;
+        dst_sig_data->sig_size = src_sig_data->sig_size;
+
+        if (src_sig_data->seq_handle != ESYS_TR_NONE) {
+            /* duplicate sequence handle */
+
+            r = Esys_ContextSave(src_sig_data->key->esys_ctx,
+                                 src_sig_data->seq_handle, &context);
+            ERRchktss(digest_sign_copy, r, goto error);
+            dst_sig_data->seq_handle = ESYS_TR_NONE;
+            r = Esys_ContextLoad(src_sig_data->key->esys_ctx, context,
+                                 &dst_sig_data->seq_handle);
+            ERRchktss(digest_sign_copy, r, goto error);
+        }
+
+        dst_sig_data->key = src_sig_data->key;
+        atomic_fetch_add(&dst_sig_data->key->refcount, 1);
+
+        EVP_PKEY_CTX_set_app_data(dst, dst_sig_data);
+    }
+
+    free(context);
+    return 1;
+
+ error:
+    free(context);
+    free(dst_sig_data);
+    return 0;
+}
+
+/**
+ * Clean up digest and sign context
+ *
+ * @param ctx OpenSSL pkey context
+ * @retval 1 on success
+ * @retval 0 on failure
+ */
+void
+digest_sign_cleanup(EVP_PKEY_CTX *ctx)
+{
+    TPM2_SIG_DATA *sig_data = EVP_PKEY_CTX_get_app_data(ctx);
+
+    if (sig_data) {
+        if (sig_data->seq_handle != ESYS_TR_NONE)
+            Esys_FlushContext(sig_data->key->esys_ctx, sig_data->seq_handle);
+
+        if (atomic_fetch_sub(&sig_data->key->refcount, 1) == 1) {
+            if (sig_data->key->key_handle != ESYS_TR_NONE) {
+                if (sig_data->key->privatetype == KEY_TYPE_HANDLE) {
+                    Esys_TR_Close(sig_data->key->esys_ctx,
+                                  &sig_data->key->key_handle);
+                } else {
+                    Esys_FlushContext(sig_data->key->esys_ctx,
+                                      sig_data->key->key_handle);
+                }
+            }
+            esys_ctx_free(&sig_data->key->esys_ctx);
+            free(sig_data->key);
+        }
+        free(sig_data);
+        EVP_PKEY_CTX_set_app_data(ctx, NULL);
+    }
+}

--- a/src/tpm2-tss-engine-err.h
+++ b/src/tpm2-tss-engine-err.h
@@ -104,6 +104,7 @@ void ERR_error(int function, int reason, const char *file, int line);
 #define TPM2TSS_F_rsa_priv_dec     141
 #define TPM2TSS_F_tpm2tss_rsa_genkey    142
 #define TPM2TSS_F_populate_rsa          143
+#define TPM2TSS_F_rsa_signctx           144
 
 /* Reason codes */
 #define TPM2TSS_R_TPM2DATA_READ_FAILED  100

--- a/src/tpm2-tss-engine-err.h
+++ b/src/tpm2-tss-engine-err.h
@@ -90,6 +90,13 @@ void ERR_error(int function, int reason, const char *file, int line);
 #define TPM2TSS_F_tpm2tss_ecc_makekey      123
 #define TPM2TSS_F_ecdh_compute_key      124
 
+/* tpm2-tss-engine-digest-sign.c */
+#define TPM2TSS_F_digest_init   150
+#define TPM2TSS_F_digest_update 151
+#define TPM2TSS_F_digest_finish 152
+#define TPM2TSS_F_digest_sign_init      153
+#define TPM2TSS_F_digest_sign_copy      154
+
 /* tpm2-tss-engine-rand.c */
 #define TPM2TSS_F_rand_bytes    130
 /* tpm2-tss-engine-rsa.c */

--- a/test/ecdsa-restricted.sh
+++ b/test/ecdsa-restricted.sh
@@ -1,0 +1,50 @@
+#!/bin/bash
+
+set -eufx
+
+echo -n "abcde12345abcde12345">mydata.txt
+
+# Create a Primary key pair
+echo "Generating primary key"
+PARENT_CTX=primary_owner_key.ctx
+
+tpm2_createprimary --hierarchy=o --hash-algorithm=sha256 --key-algorithm=ecc \
+                   --key-context=${PARENT_CTX}
+tpm2_flushcontext --transient-object
+
+# Create an ECDSA key pair
+echo "Generating ECDSA key pair"
+TPM_ECDSA_PUBKEY=ecdsakey.pub
+TPM_ECDSA_KEY=ecdsakey
+tpm2_create --parent-context=${PARENT_CTX} \
+            --hash-algorithm=sha256 --key-algorithm=ecc256:ecdsa-sha256:null \
+            --public=${TPM_ECDSA_PUBKEY} --private=${TPM_ECDSA_KEY} \
+            --attributes=sign\|restricted\|fixedtpm\|fixedparent\|sensitivedataorigin\|userwithauth\|noda
+tpm2_flushcontext --transient-object
+
+# Load Key to persistent handle
+ECDSA_CTX=ecdsakey.ctx
+tpm2_load --parent-context=${PARENT_CTX} \
+          --public=${TPM_ECDSA_PUBKEY} --private=${TPM_ECDSA_KEY} \
+          --key-context=${ECDSA_CTX}
+tpm2_flushcontext --transient-object
+
+HANDLE=$(tpm2_evictcontrol --hierarchy=o --object-context=${ECDSA_CTX} | cut -d ' ' -f 2 | head -n 1)
+tpm2_flushcontext --transient-object
+
+tpm2_readpublic --object-context=${HANDLE}
+
+# Digest & sign Data
+openssl dgst -engine tpm2tss -keyform engine -sha256 -sign ${HANDLE} -out mysig mydata.txt
+
+# Get public key of handle
+tpm2_readpublic --object-context=${HANDLE} --output=mykey.pem --format=pem
+
+# Release persistent HANDLE
+tpm2_evictcontrol --hierarchy=o --object-context=${HANDLE}
+
+R="$(openssl dgst -verify mykey.pem -sha256 -signature mysig mydata.txt || true)"
+if ! echo $R | grep "Verified OK" >/dev/null; then
+    echo $R
+    exit 1
+fi

--- a/test/rsasign_restricted.sh
+++ b/test/rsasign_restricted.sh
@@ -1,0 +1,50 @@
+#!/bin/bash
+
+set -eufx
+
+echo -n "abcde12345abcde12345">mydata.txt
+
+# Create a Primary key pair
+echo "Generating primary key"
+PARENT_CTX=primary_owner_key.ctx
+
+tpm2_createprimary --hierarchy=o --hash-algorithm=sha256 --key-algorithm=rsa \
+                   --key-context=${PARENT_CTX}
+tpm2_flushcontext --transient-object
+
+# Create an RSA key pair
+echo "Generating RSA key pair"
+TPM_RSA_PUBKEY=rsakey.pub
+TPM_RSA_KEY=rsakey
+tpm2_create --parent-context=${PARENT_CTX} \
+            --hash-algorithm=sha256 --key-algorithm=rsa:rsassa-sha256:null \
+            --public=${TPM_RSA_PUBKEY} --private=${TPM_RSA_KEY} \
+            --attributes=sign\|restricted\|fixedtpm\|fixedparent\|sensitivedataorigin\|userwithauth\|noda
+tpm2_flushcontext --transient-object
+
+# Load Key to persistent handle
+RSA_CTX=rsakey.ctx
+tpm2_load --parent-context=${PARENT_CTX} \
+          --public=${TPM_RSA_PUBKEY} --private=${TPM_RSA_KEY} \
+          --key-context=${RSA_CTX}
+tpm2_flushcontext --transient-object
+
+HANDLE=$(tpm2_evictcontrol --hierarchy=o --object-context=${RSA_CTX} | cut -d ' ' -f 2 | head -n 1)
+tpm2_flushcontext --transient-object
+
+tpm2_readpublic --object-context=${HANDLE}
+
+# Digest & sign Data
+openssl dgst -engine tpm2tss -keyform engine -sha256 -sign ${HANDLE} -out mysig mydata.txt
+
+# Get public key of handle
+tpm2_readpublic --object-context=${HANDLE} --output=mykey.pem --format=pem
+
+# Release persistent HANDLE
+tpm2_evictcontrol --hierarchy=o --object-context=${HANDLE}
+
+R="$(openssl dgst -verify mykey.pem -sha256 -signature mysig mydata.txt || true)"
+if ! echo $R | grep "Verified OK" >/dev/null; then
+    echo $R
+    exit 1
+fi


### PR DESCRIPTION
The TPM architecture mandates that a restricted signing key may only
sign a digest that has been produced by the TPM. Having a TPM key be
restricted is useful for implementing attestation using the key.

The current mechanism for signing data using OpenSSL with an ECC key
is through the EC_KEY sign method. This is too low-level, since it
relies on the digest having already been done (in software). The EVP
pkey object is the right level, since OpenSSL exposes EVP_DigestSign*
functions that operate on it.
    
So implement methods on EVP pkey for digest and sign for the EC type,
inheriting other EVP pkey methods from the built-in EC type in
OpenSSL. The digest and sign operation is implemented by making use of
the TPM to perform the digest and then passing the validation ticket,
which is required for a restricted key, (along with digest data) into
the subsequent sign operation in the TPM.
    
Make use of the digest_custom method, rather than signctx_init method
for performing initialisation of our context used for the
digest-and-sign operation so that the message digest type is already
set in the OpenSSL message digest context. It isn't possible to
override the builtin methods registered for OpenSSL message digest
types in a general sense, but it is possible to override the update
method called during a updating digest data in the context of
EVP_DigestSign* functions, so this is what is done to allow the digest
update to be performed in the TPM.
    
Whilst this is only implemented for ECC keys currently, the
implementation is done in a way where the parts not specific to the
key type are in a file not specific to the key type, so that they can
be used for doing the same with RSA in the future.
