### PR TITLE
Fix allocation scopes

### DIFF
--- a/src/tpm2-tss-engine-common.c
+++ b/src/tpm2-tss-engine-common.c
@@ -318,7 +318,7 @@ session_error:
 
     esys_ctx_free(&esys_ctx);
     tpm2Data->pub = *outPublic;
-    free(outPublic);
+    Esys_Free(outPublic);
 
     *tpm2Datap = tpm2Data;
     return 1;
@@ -524,8 +524,7 @@ init_tpm_parent(ESYS_CONTEXT **esys_ctx,
         }
     }
 
-    if (capabilityData != NULL)
-        free (capabilityData);
+    Esys_Free (capabilityData);
 
     if (primaryTemplate == NULL) {
         ERR(init_tpm_parent, TPM2TSS_R_UNKNOWN_ALG);
@@ -694,6 +693,6 @@ tpm2tss_tpm2data_importtpm(const char *filenamepub, const char *filenametpm,
     return 1;
 
   error:
-    free(tpm2data);
+    OPENSSL_free(tpm2data);
     return 0;
 }

--- a/src/tpm2-tss-engine-digest-sign.c
+++ b/src/tpm2-tss-engine-digest-sign.c
@@ -172,7 +172,7 @@ digest_sign_init(EVP_PKEY_CTX *ctx, EVP_MD_CTX *mctx, TPM2_DATA *tpm2data,
         /* non-TPM key - nothing to do */
         return 1;
 
-    TPM2_SIG_DATA *data = calloc(sizeof(*data), 1);
+    TPM2_SIG_DATA *data = OPENSSL_malloc(sizeof(*data));
     if (!data) {
         ERR(digest_sign_init, ERR_R_MALLOC_FAILURE);
         return 0;
@@ -181,7 +181,7 @@ digest_sign_init(EVP_PKEY_CTX *ctx, EVP_MD_CTX *mctx, TPM2_DATA *tpm2data,
     data->seq_handle = ESYS_TR_NONE;
     data->sig_size = sig_size;
 
-    data->key = calloc(sizeof(*data->key), 1);
+    data->key = OPENSSL_malloc(sizeof(*data->key));
     if (!data->key) {
         ERR(digest_sign_init, ERR_R_MALLOC_FAILURE);
         goto error;
@@ -218,9 +218,9 @@ digest_sign_init(EVP_PKEY_CTX *ctx, EVP_MD_CTX *mctx, TPM2_DATA *tpm2data,
         }
         if (data->key->esys_ctx)
             esys_ctx_free(&data->key->esys_ctx);
-        free(data->key);
+        OPENSSL_free(data->key);
     }
-    free(data);
+    OPENSSL_free(data);
     return 0;
 }
 
@@ -241,7 +241,7 @@ digest_sign_copy(EVP_PKEY_CTX *dst, EVP_PKEY_CTX *src)
     TSS2_RC r;
 
     if (src_sig_data) {
-        dst_sig_data = calloc(sizeof(*dst_sig_data), 1);
+        dst_sig_data = OPENSSL_malloc(sizeof(*dst_sig_data));
         if (!dst_sig_data) {
             ERR(digest_sign_copy, ERR_R_MALLOC_FAILURE);
             return 0;
@@ -268,12 +268,12 @@ digest_sign_copy(EVP_PKEY_CTX *dst, EVP_PKEY_CTX *src)
         EVP_PKEY_CTX_set_app_data(dst, dst_sig_data);
     }
 
-    free(context);
+    Esys_Free(context);
     return 1;
 
  error:
-    free(context);
-    free(dst_sig_data);
+    Esys_Free(context);
+    OPENSSL_free(dst_sig_data);
     return 0;
 }
 
@@ -304,9 +304,9 @@ digest_sign_cleanup(EVP_PKEY_CTX *ctx)
                 }
             }
             esys_ctx_free(&sig_data->key->esys_ctx);
-            free(sig_data->key);
+            OPENSSL_free(sig_data->key);
         }
-        free(sig_data);
+        OPENSSL_free(sig_data);
         EVP_PKEY_CTX_set_app_data(ctx, NULL);
     }
 }

--- a/src/tpm2-tss-engine-ecc.c
+++ b/src/tpm2-tss-engine-ecc.c
@@ -284,7 +284,7 @@ ecdsa_sign(ESYS_CONTEXT *esys_ctx, ESYS_TR key_handle,
       ECDSA_SIG_free(ret);
     ret = NULL;
  out:
-    free(sig);
+    Esys_Free(sig);
     return ret;
 }
 
@@ -483,8 +483,8 @@ ecdsa_signctx(EVP_PKEY_CTX *ctx, unsigned char *sig, size_t *siglen,
     r = 0;
  out:
     ECDSA_SIG_free(ecdsa_s);
-    free(digest_ptr);
-    free(validation_ptr);
+    Esys_Free(digest_ptr);
+    Esys_Free(validation_ptr);
 
     return r;
 }
@@ -785,8 +785,8 @@ tpm2tss_ecc_genkey(EC_KEY *key, TPMI_ECC_CURVE curve, const char *password,
         OPENSSL_free(tpm2Data);
 
  end:
-    free(keyPrivate);
-    free(keyPublic);
+    Esys_Free(keyPrivate);
+    Esys_Free(keyPublic);
 
     if (parent != ESYS_TR_NONE && !parentHandle)
         Esys_FlushContext(esys_ctx, parent);

--- a/src/tpm2-tss-engine-rand.c
+++ b/src/tpm2-tss-engine-rand.c
@@ -107,7 +107,7 @@ rand_bytes(unsigned char *buf, int num)
         memcpy(buf, &b->buffer, b->size);
         num -= b->size;
         buf += b->size;
-        free(b);
+        Esys_Free(b);
     }
 
     esys_ctx_free(&esys_ctx);

--- a/src/tpm2-tss-engine-rsa.c
+++ b/src/tpm2-tss-engine-rsa.c
@@ -188,7 +188,7 @@ rsa_priv_enc(int flen, const unsigned char *from, unsigned char *to, RSA *rsa,
     r = -1;
 
  out:
-    free(sig);
+    Esys_Free(sig);
     if (keyHandle != ESYS_TR_NONE) {
         if (tpm2Data->privatetype == KEY_TYPE_HANDLE) {
             Esys_TR_Close(esys_ctx, &keyHandle);
@@ -280,7 +280,7 @@ rsa_priv_dec(int flen, const unsigned char *from, unsigned char *to, RSA * rsa,
     r = -1;
 
  out:
-    free(message);
+    Esys_Free(message);
     if (keyHandle != ESYS_TR_NONE) {
         if (tpm2Data->privatetype == KEY_TYPE_HANDLE) {
             Esys_TR_Close(esys_ctx, &keyHandle);
@@ -602,8 +602,8 @@ tpm2tss_rsa_genkey(RSA *rsa, int bits, BIGNUM *e, char *password,
         OPENSSL_free(tpm2Data);
 
  end:
-    free(keyPrivate);
-    free(keyPublic);
+    Esys_Free(keyPrivate);
+    Esys_Free(keyPublic);
 
     if (parent != ESYS_TR_NONE && !parentHandle)
         Esys_FlushContext(esys_ctx, parent);
@@ -731,9 +731,9 @@ rsa_signctx(EVP_PKEY_CTX *ctx, unsigned char *sig, size_t *siglen,
  error:
     r = 0;
  out:
-    free(tpm_sig);
-    free(digest_ptr);
-    free(validation_ptr);
+    Esys_Free(tpm_sig);
+    Esys_Free(digest_ptr);
+    Esys_Free(validation_ptr);
 
     return r;
 }

--- a/src/tpm2tss-genkey.c
+++ b/src/tpm2tss-genkey.c
@@ -265,7 +265,7 @@ genkey_rsa()
 
     VERB("Key generated\n");
 
-    TPM2_DATA *tpm2Data = calloc(1, sizeof(*tpm2Data));
+    TPM2_DATA *tpm2Data = OPENSSL_malloc(sizeof(*tpm2Data));
     if (tpm2Data == NULL) {
         ERR("out of memory\n");
         BN_free(e);
@@ -302,7 +302,7 @@ genkey_ecdsa()
         return NULL;
     }
 
-    TPM2_DATA *tpm2Data = calloc(1, sizeof(*tpm2Data));
+    TPM2_DATA *tpm2Data = OPENSSL_malloc(sizeof(*tpm2Data));
     if (tpm2Data == NULL) {
         ERR("out of memory\n");
         EC_KEY_free(eckey);
@@ -404,11 +404,11 @@ main(int argc, char **argv)
 
     if (!tpm2tss_tpm2data_write(tpm2Data, opt.filename)) {
         ERR("Error writing file\n");
-        free(tpm2Data);
+        OPENSSL_free(tpm2Data);
         return 1;
     }
 
-    free(tpm2Data);
+    OPENSSL_free(tpm2Data);
 
     VERB("*** SUCCESS ***\n");
     return 0;


### PR DESCRIPTION
Use Esys_Free for Esys allocated return parameters.
Use OPENSSL_free for OPENSSL_malloc memory.
Unify to use only OPENSSL_malloc instead of calloc.

Fixes: #245 