### PR TITLE
digest-sign: fix digest of large chunks of data

### DIFF
--- a/test/ecdsa-restricted.sh
+++ b/test/ecdsa-restricted.sh
@@ -2,7 +2,9 @@
 
 set -eufx
 
-echo -n "abcde12345abcde12345">mydata.txt
+# Generate 2k + a bit of data
+dd if=/dev/zero of=mydata.txt count=4 bs=512 status=none
+echo -n "abcde12345abcde12345">>mydata.txt
 
 # Create a Primary key pair
 echo "Generating primary key"

--- a/test/rsasign_restricted.sh
+++ b/test/rsasign_restricted.sh
@@ -2,7 +2,9 @@
 
 set -eufx
 
-echo -n "abcde12345abcde12345">mydata.txt
+# Generate 2k + a bit of data
+dd if=/dev/zero of=mydata.txt count=4 bs=512 status=none
+echo -n "abcde12345abcde12345">>mydata.txt
 
 # Create a Primary key pair
 echo "Generating primary key"


### PR DESCRIPTION
Fix the use of digest on chunks of data larger than the buffer size
supported by the TPM by iteratively calling Esys_SequenceUpdate on the
chunks until all the data is consumed.

Extend the restricted signing tests to cover this case.

Fixes #248

Signed-off-by: Rob Shearman <rob@graphiant.com>