### PR TITLE
VERSION: add version file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,3 +43,4 @@ man/*.7
 test/error_tpm2-tss-engine-common
 test/*.o
 config.h.in
+VERSION

--- a/Makefile.am
+++ b/Makefile.am
@@ -164,7 +164,8 @@ EXTRA_DIST += \
     CONTRIBUTING.md \
     INSTALL.md \
     LICENSE \
-    README.md
+    README.md \
+    VERSION
 
 # Generate the AUTHORS file from git log
 AUTHORS:

--- a/bootstrap
+++ b/bootstrap
@@ -2,4 +2,6 @@
 
 set -e
 
+git describe --tags --always --dirty > VERSION
+
 autoreconf --install --sym

--- a/configure.ac
+++ b/configure.ac
@@ -31,7 +31,7 @@
 AC_PREREQ([2.68])
 
 AC_INIT([tpm2-tss-engine],
-        [m4_esyscmd_s([git describe --tags --always --dirty])],
+        [m4_esyscmd_s([cat ./VERSION])],
         [https://github.com/tpm2-software/tpm2-tss-engine/issues],
         [],
         [https://github.com/tpm2-software/tpm2-tss-engine])


### PR DESCRIPTION
Generate the version file with bootstrap and include in the DIST tarball
so endusers can call autoreconf on a dist tarball which doesn't have
git. This alleviates git describe errors on release tarballs in the
autoreconf case.

Signed-off-by: William Roberts <william.c.roberts@intel.com>