### PR TITLE
Remove deprecated value from openssl.conf.sample > default_algorithms

### DIFF
--- a/openssl.conf.sample
+++ b/openssl.conf.sample
@@ -9,7 +9,7 @@ tpm2tss = tpm2tss_section
 [tpm2tss_section]
 engine_id = tpm2tss
 dynamic_path = /usr/lib/engines-1.1/libtpm2tss.so
-default_algorithms = RSA,ECDSA
+default_algorithms = RSA
 init = 1
 #SET_TCTI = <TCTI_options>
 #SET_OWNERAUTH = <could_set_password_here, but then it's readable>


### PR DESCRIPTION
In `openssl.conf.sample`, the value `ECDSA` has been removed since OpenSSL_1_1_0-pre1 in this [commit](https://github.com/openssl/openssl/commit/1eb97c3ecd5a9c7faa9436d506735be0bd7c3b4b#diff-14dfb541c246d67b67ccfa6f47883b4a7517a38bfba187941df0b6468ab815a7L110). 

It seems harmless, but if the [parser](https://github.com/openssl/openssl/blob/OpenSSL_1_1_0-pre1/crypto/engine/eng_cnf.c#L91) encountered an invalid option, it will exit silently. Meaning, everything come after the line `default_algorithms = RSA,ECDSA` are ignored.

On top of that, since the tss engine is not using the `ENGINE_set_ECDSA()` approach, hence it is safe to remove the value from `default_algorithms`.

This PR is to address issue https://github.com/tpm2-software/tpm2-tss-engine/issues/260

Signed-off-by: wenxin.leong <wenxin.leong@infineon.com>

Resolves [#260](https://github.com/tpm2-software/tpm2-tss-engine/issues/260)