### PR TITLE
rsa: fix OAEP padding decryption

### DIFF
--- a/.ci/docker.run
+++ b/.ci/docker.run
@@ -3,6 +3,8 @@
 
 set -exo pipefail
 
+git config --global --add safe.directory /workspace/tpm2-tss-engine
+
 $DOCKER_BUILD_DIR/.ci/get_deps.sh "$(dirname $DOCKER_BUILD_DIR)"
 
 pushd $DOCKER_BUILD_DIR

--- a/src/tpm2-tss-engine-rsa.c
+++ b/src/tpm2-tss-engine-rsa.c
@@ -251,6 +251,9 @@ rsa_priv_dec(int flen, const unsigned char *from, unsigned char *to, RSA * rsa,
         inScheme.scheme = TPM2_ALG_OAEP;
         inScheme.details.oaep.hashAlg = TPM2_ALG_SHA1;
         break;
+    case RSA_NO_PADDING:
+        inScheme.scheme = TPM2_ALG_NULL;
+        break;
     default:
         ERR(rsa_priv_dec, TPM2TSS_R_PADDING_UNKNOWN);
         goto error;


### PR DESCRIPTION
With OpenSSL 1.1.1, using RSA OAEP as rsa_padding_mode failed with error that the padding mode was unknown. This is because the OpenSSL EVP_PKEY_METH for decryption, pkey_rsa_decrypt(), calls the RSA decrypt method with RSA_NO_PADDING as padding, and then checks the OAEP padding after raw decryption. This patch fixes the use of OAEP decryption by allow RSA_NO_PADDING as an accepted padding value and uses inScheme to the TPM as TPM_ALG_NULL, allowing RSA OAEP decryption to work correctly.

Signed-off-by: Raghu Krishnamurthy <raghupathyk@nvidia.com>