### PR TITLE
Makefile.am: Fix build without pandoc

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -217,8 +217,10 @@ EXTRA_DIST += \
     man/tpm2tss_ecc_genkey.3.md \
     man/tpm2tss_ecc_getappdata.3.md
 
+if HAVE_PANDOC
 CLEANFILES += \
     $(dist_man_MANS)
+endif
 
 ### Bash Completion
 bash_completiondir = $(completionsdir)


### PR DESCRIPTION
When building from a tarball, pre-created man pages are preset. Yet `make clean` clobbers them, leaving their target directory intact. Therefore, the next configure call will try to build man pages even if pandoc isn't available.

Fix this by cleaning the man pages only if they can be recreated by the presence of pandoc.

Fixes https://github.com/tpm2-software/tpm2-tss-engine/issues/284