### PR TITLE
fix memory leaks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,8 @@
 Makefile
 Makefile.in
 aclocal.m4
+ax_*.m4
+pkg.m4
 aminclude_static.am
 autom4te.cache/
 compile
@@ -16,6 +18,7 @@ install-sh
 libtool
 libtpm2.la
 ltmain.sh
+stamp-h1
 m4/libtool.m4
 m4/ltoptions.m4
 m4/ltsugar.m4
@@ -26,6 +29,7 @@ src/.dirstamp
 src/.libs/
 src/*.o
 src/*.lo
+src/config.h
 tpm2tss-genkey
 libtpm2tss.la
 *.gcno
@@ -44,3 +48,5 @@ test/error_tpm2-tss-engine-common
 test/*.o
 config.h.in
 VERSION
+build/
+.vscode/

--- a/src/tpm2-tss-engine-common.c
+++ b/src/tpm2-tss-engine-common.c
@@ -163,10 +163,7 @@ tpm2tss_tpm2data_write(const TPM2_DATA *tpm2Data, const char *filename)
         goto error;
     }
     tpk->type = OBJ_txt2obj(OID_loadableKey, 1);
-    tpk->parent = ASN1_INTEGER_new();
-    tpk->privkey = ASN1_OCTET_STRING_new();
-    tpk->pubkey = ASN1_OCTET_STRING_new();
-    if (!tpk->type || !tpk->privkey || !tpk->pubkey || !tpk->parent) {
+    if (!tpk->type) {
         ERR(tpm2tss_tpm2data_write, ERR_R_MALLOC_FAILURE);
         goto error;
     }

--- a/src/tpm2-tss-engine-common.c
+++ b/src/tpm2-tss-engine-common.c
@@ -182,6 +182,8 @@ tpm2tss_tpm2data_write(const TPM2_DATA *tpm2Data, const char *filename)
         BN_set_word(bn_parent, TPM2_RH_OWNER);
     }
     BN_to_ASN1_INTEGER(bn_parent, tpk->parent);
+    BN_free(bn_parent);
+
     ASN1_STRING_set(tpk->privkey, &privbuf[0], privbuf_len);
     ASN1_STRING_set(tpk->pubkey, &pubbuf[0], pubbuf_len);
 
@@ -195,6 +197,8 @@ tpm2tss_tpm2data_write(const TPM2_DATA *tpm2Data, const char *filename)
         BIO_free(bio);
     if (tpk)
         TSSPRIVKEY_free(tpk);
+    if (bn_parent)
+        BN_free(bn_parent);
     return 0;
 }
 
@@ -347,7 +351,7 @@ tpm2tss_tpm2data_read(const char *filename, TPM2_DATA **tpm2Datap)
     TSSPRIVKEY *tpk = NULL;
     TPM2_DATA *tpm2Data = NULL;
     char type_oid[64];
-    BIGNUM *bn_parent;
+    BIGNUM *bn_parent = NULL;
 
     if ((bio = BIO_new_file(filename, "r")) == NULL) {
         ERR(tpm2tss_tpm2data_read, TPM2TSS_R_FILE_READ);
@@ -382,6 +386,8 @@ tpm2tss_tpm2data_read(const char *filename, TPM2_DATA **tpm2Datap)
     } else {
         tpm2Data->parent = BN_get_word(bn_parent);
     }
+    BN_free(bn_parent);
+
     if (tpm2Data->parent == 0)
         tpm2Data->parent = TPM2_RH_OWNER;
 
@@ -415,6 +421,8 @@ tpm2tss_tpm2data_read(const char *filename, TPM2_DATA **tpm2Datap)
         BIO_free(bio);
     if (tpk)
         TSSPRIVKEY_free(tpk);
+    if (bn_parent)
+        BN_free(bn_parent);
 
     return 0;
 }

--- a/src/tpm2tss-genkey.c
+++ b/src/tpm2tss-genkey.c
@@ -265,14 +265,7 @@ genkey_rsa()
 
     VERB("Key generated\n");
 
-    TPM2_DATA *tpm2Data = OPENSSL_malloc(sizeof(*tpm2Data));
-    if (tpm2Data == NULL) {
-        ERR("out of memory\n");
-        BN_free(e);
-        RSA_free(rsa);
-        return NULL;
-    }
-    memcpy(tpm2Data, RSA_get_app_data(rsa), sizeof(*tpm2Data));
+    TPM2_DATA *tpm2Data = RSA_get_app_data(rsa);
 
     BN_free(e);
     RSA_free(rsa);


### PR DESCRIPTION
- BIGNUM must be freed both on tpm2tss_tpm2data_write and tpm2tss_tpm2data_read:
definitely lost: 24 bytes in 1 blocks
indirectly lost: 8 bytes in 1 blocks
- TSSPRIVKEY's parent, privkey and pubkey members don't need to be allocated explicitly, because TSSPRIVKEY_new already does:
definitely lost: 72 bytes in 3 blocks
indirectly lost: 0 bytes in 0 blocks
- TPM2_DATA* returned from RSA_get_app_data can be returned directly genkey_rsa() because RSA_free() doesn't free this item:
definitely lost: 2,248 bytes in 1 blocks
indirectly lost: 0 bytes in 0 blocks
- update .gitignore to cover more generated files