### PR TITLE
bug: fix const correctness bugs

### DIFF
--- a/.ci/docker.run
+++ b/.ci/docker.run
@@ -5,6 +5,10 @@ set -exo pipefail
 
 git config --global --add safe.directory /workspace/tpm2-tss-engine
 
+# some distros use different prefix and path settings, rather than
+# configure all that, this simply fixes the problem.
+export LD_LIBRARY_PATH="/usr/local/lib"
+
 $DOCKER_BUILD_DIR/.ci/get_deps.sh "$(dirname $DOCKER_BUILD_DIR)"
 
 pushd $DOCKER_BUILD_DIR

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -26,36 +26,6 @@ jobs:
       - name: failure
         if: ${{ failure() }}
         run: cat build/test-suite.log || true
-  multi-arch:
-    runs-on: ubuntu-latest
-    if: "!contains(github.ref, 'coverity_scan')"
-    strategy:
-      matrix:
-        ARCH: [
-          "ubuntu-20.04.arm32v7",
-        ]
-        TPM2TSS_BRANCH: ["3.0.x"]
-        TPM2TOOLS_BRANCH: ["4.0"]
-    steps:
-      - name: Setup QEMU
-        run: |
-          sudo apt-get update
-          sudo apt-get install qemu binfmt-support qemu-user-static
-          docker run --rm --privileged multiarch/qemu-user-static --reset -p yes
-      - name: Check out repository
-        uses: actions/checkout@v2
-      - name: Launch Action
-        uses:
-          tpm2-software/ci/runCI@main
-        with:
-          PROJECT_NAME: ${{ github.event.repository.name }}
-          DOCKER_IMAGE: ${{ matrix.ARCH }}
-          TPM2TSS_BRANCH: "${{ matrix.TPM2TSS_BRANCH }}"
-          TPM2TOOLS_BRANCH: "${{ matrix.TPM2TOOLS_BRANCH }}"
-          CC: gcc
-      - name: failure
-        if: ${{ failure() }}
-        run: find -name test-suite.log | xargs cat || true
   coverity-test:
     runs-on: ubuntu-latest
     if: contains(github.ref, 'coverity_scan') && github.event_name == 'push'

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -7,7 +7,7 @@ jobs:
     if: "!contains(github.ref, 'coverity_scan')"
     strategy:
       matrix:
-        DOCKER_IMAGE: [ "ubuntu-18.04", "ubuntu-20.04", "fedora-32", "opensuse-leap" ]
+        DOCKER_IMAGE: [ "ubuntu-18.04", "ubuntu-20.04", "fedora-32" ]
         TPM2TSS_BRANCH: ["3.0.x"]
         TPM2TOOLS_BRANCH: ["4.0"]
         CC: ["gcc", "clang"]

--- a/configure.ac
+++ b/configure.ac
@@ -93,6 +93,7 @@ AS_IF([test "x$enable_defaultflags" = "xyes"],
       AX_ADD_COMPILER_FLAG([-fstack-protector-all])
       AX_ADD_COMPILER_FLAG([-fpic])
       AX_ADD_COMPILER_FLAG([-fPIC])
+      AX_ADD_COMPILER_FLAG([-Wno-deprecated-declarations])
 
       # work around GCC bug #53119
       #   https://gcc.gnu.org/bugzilla/show_bug.cgi?id=53119

--- a/src/tpm2-tss-engine-common.h
+++ b/src/tpm2-tss-engine-common.h
@@ -192,8 +192,20 @@ int
 digest_sign_init(EVP_PKEY_CTX *ctx, EVP_MD_CTX *mctx, TPM2_DATA *tpm2data,
                  size_t sig_size);
 int
-digest_sign_copy(EVP_PKEY_CTX *dst, EVP_PKEY_CTX *src);
+digest_sign_copy(EVP_PKEY_CTX *dst, const EVP_PKEY_CTX *src);
 void
 digest_sign_cleanup(EVP_PKEY_CTX *ctx);
+
+/*
+ * OpenSSL APIs change const values between legacy
+ * 1.x and the newer 3.x version. OpenSSL 3 and above
+ * uses const in places that 1.x doesn't. Lets just
+ * match what is expected.
+ */
+#if OPENSSL_VERSION_NUMBER >= 0x30000000L
+#define OSSL_CONST const
+#else
+#define OSSL_CONST
+#endif
 
 #endif /* TPM2_TSS_ENGINE_COMMON_H */

--- a/src/tpm2-tss-engine-digest-sign.c
+++ b/src/tpm2-tss-engine-digest-sign.c
@@ -236,9 +236,9 @@ digest_sign_init(EVP_PKEY_CTX *ctx, EVP_MD_CTX *mctx, TPM2_DATA *tpm2data,
  * @retval 0 on failure
  */
 int
-digest_sign_copy(EVP_PKEY_CTX *dst, EVP_PKEY_CTX *src)
+digest_sign_copy(EVP_PKEY_CTX *dst, const EVP_PKEY_CTX *src)
 {
-    TPM2_SIG_DATA *src_sig_data = EVP_PKEY_CTX_get_app_data(src);
+    TPM2_SIG_DATA *src_sig_data = EVP_PKEY_CTX_get_app_data((EVP_PKEY_CTX *)src);
     TPMS_CONTEXT *context = NULL;
     TPM2_SIG_DATA *dst_sig_data = NULL;
     TSS2_RC r;

--- a/src/tpm2-tss-engine-ecc.c
+++ b/src/tpm2-tss-engine-ecc.c
@@ -52,7 +52,7 @@ EC_KEY_METHOD *ecc_methods = NULL;
 #endif /* OPENSSL_VERSION_NUMBER < 0x10100000 */
 
 #ifdef HAVE_OPENSSL_DIGEST_SIGN
-static int (*ecdsa_pkey_orig_copy)(EVP_PKEY_CTX *dst, const EVP_PKEY_CTX *src);
+static int (*ecdsa_pkey_orig_copy)(EVP_PKEY_CTX *dst, OSSL_CONST EVP_PKEY_CTX *src);
 static void (*ecdsa_pkey_orig_cleanup)(EVP_PKEY_CTX *ctx);
 #endif /* HAVE_OPENSSL_DIGEST_SIGN */
 
@@ -405,7 +405,7 @@ ecdsa_ec_key_sign(const unsigned char *dgst, int dgst_len, const BIGNUM *inv,
 
 #ifdef HAVE_OPENSSL_DIGEST_SIGN
 static int
-ecdsa_pkey_copy(EVP_PKEY_CTX *dst, const EVP_PKEY_CTX *src)
+ecdsa_pkey_copy(EVP_PKEY_CTX *dst, OSSL_CONST EVP_PKEY_CTX *src)
 {
     if (ecdsa_pkey_orig_copy && !ecdsa_pkey_orig_copy(dst, src))
         return 0;
@@ -427,7 +427,7 @@ static int
 ecdsa_digest_custom(EVP_PKEY_CTX *ctx, EVP_MD_CTX *mctx)
 {
     EVP_PKEY *pkey = EVP_PKEY_CTX_get0_pkey(ctx);
-    EC_KEY *eckey = EVP_PKEY_get0_EC_KEY(pkey);
+    const EC_KEY *eckey = EVP_PKEY_get0_EC_KEY(pkey);
     TPM2_DATA *tpm2data = tpm2tss_ecc_getappdata(eckey);
 
     DBG("ecdsa_digest_custom %p %p\n", ctx, mctx);

--- a/src/tpm2-tss-engine-rsa.c
+++ b/src/tpm2-tss-engine-rsa.c
@@ -49,7 +49,7 @@ RSA_METHOD *rsa_methods = NULL;
 #endif /* OPENSSL_VERSION_NUMBER < 0x10100000 */
 
 #ifdef HAVE_OPENSSL_DIGEST_SIGN
-static int (*rsa_pkey_orig_copy)(EVP_PKEY_CTX *dst, const EVP_PKEY_CTX *src);
+static int (*rsa_pkey_orig_copy)(EVP_PKEY_CTX *dst, OSSL_CONST EVP_PKEY_CTX *src);
 static void (*rsa_pkey_orig_cleanup)(EVP_PKEY_CTX *ctx);
 #endif /* HAVE_OPENSSL_DIGEST_SIGN */
 
@@ -637,7 +637,7 @@ RSA_METHOD rsa_methods = {
 
 #ifdef HAVE_OPENSSL_DIGEST_SIGN
 static int
-rsa_pkey_copy(EVP_PKEY_CTX *dst, const EVP_PKEY_CTX *src)
+rsa_pkey_copy(EVP_PKEY_CTX *dst, OSSL_CONST EVP_PKEY_CTX *src)
 {
     if (rsa_pkey_orig_copy && !rsa_pkey_orig_copy(dst, src))
         return 0;
@@ -659,7 +659,7 @@ static int
 rsa_digest_custom(EVP_PKEY_CTX *ctx, EVP_MD_CTX *mctx)
 {
     EVP_PKEY *pkey = EVP_PKEY_CTX_get0_pkey(ctx);
-    RSA *rsa = EVP_PKEY_get0_RSA(pkey);
+    const RSA *rsa = EVP_PKEY_get0_RSA(pkey);
     TPM2_DATA *tpm2data = RSA_get_app_data(rsa);
 
     DBG("rsa_digest_custom %p %p\n", ctx, mctx);


### PR DESCRIPTION
Some functions, including callbacks, had const in them, while not quite right, they were not quite wrong either, but older OpenSSL was notoriously full of places where const should have been used. So, to keep the patch simple and so we don't have to cast function pointers, drop const.